### PR TITLE
Only lint on latest Elixir/OTP versions

### DIFF
--- a/.github/workflows/test_and_lint.yml
+++ b/.github/workflows/test_and_lint.yml
@@ -26,6 +26,9 @@ jobs:
           key: 24-1.12-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
           restore-keys: 24-1.12-mix
 
+      - run: mix deps.get
+        name: Fetch Dependencies
+
       - run: mix credo --strict
         name: Lint (credo)
 


### PR DESCRIPTION
Only run lint jobs on the latest version of Elixir and OTP to avoid huge times running credo on every test matrix.