### PR TITLE
Add a dedicated member cache

### DIFF
--- a/docs/static/Application Commands.md
+++ b/docs/static/Application Commands.md
@@ -100,11 +100,11 @@ alias Nostrum.Api
 alias Nostrum.Struct.Interaction
 
 defp manage_role(%Interaction{data: %{options: [%{value: role_id}, %{value: "assign"}]}} = interaction) do
-  Api.add_guild_member_role(interaction.guild_id, interaction.member.user.id, role_id)
+  Api.add_guild_member_role(interaction.guild_id, interaction.member.user_id, role_id)
 end
 
 defp manage_role(%Interaction{data: %{options: [%{value: role_id}, %{value: "remove"}]}} = interaction) do
-  Api.remove_guild_member_role(interaction.guild_id, interaction.member.user.id, role_id)
+  Api.remove_guild_member_role(interaction.guild_id, interaction.member.user_id, role_id)
 end
 
 def handle_event({:INTERACTION_CREATE, %Interaction{data: %{name: "role"}} = interaction, _ws_state}) do
@@ -122,7 +122,7 @@ To respond to interactions, use ``Nostrum.Api.create_interaction_response/2``:
 
 ```elixir
 defp manage_role(%Interaction{data: %{options: [%{value: role_id}, %{value: "assign"}]}} = interaction) do
-  Api.add_guild_member_role(interaction.guild_id, interaction.member.user.id, role_id)
+  Api.add_guild_member_role(interaction.guild_id, interaction.member.user_id, role_id)
   response = %{
     type: 4,  # ChannelMessageWithSource
     data: %{

--- a/lib/nostrum/cache/cache_supervisor.ex
+++ b/lib/nostrum/cache/cache_supervisor.ex
@@ -22,6 +22,7 @@ defmodule Nostrum.Cache.CacheSupervisor do
       Nostrum.Cache.Me,
       # Uses the configured cache implementations.
       Nostrum.Cache.GuildCache,
+      Nostrum.Cache.MemberCache,
       Nostrum.Cache.UserCache,
       Nostrum.Cache.ChannelCache,
       Nostrum.Cache.PresenceCache

--- a/lib/nostrum/cache/guild_cache.ex
+++ b/lib/nostrum/cache/guild_cache.ex
@@ -47,7 +47,6 @@ defmodule Nostrum.Cache.GuildCache do
   alias Nostrum.Struct.Channel
   alias Nostrum.Struct.Emoji
   alias Nostrum.Struct.Guild
-  alias Nostrum.Struct.Guild.Member
   alias Nostrum.Struct.Guild.Role
   alias Nostrum.Struct.Message
   alias Nostrum.Util
@@ -217,48 +216,6 @@ defmodule Nostrum.Cache.GuildCache do
               {old_emojis :: [Emoji.t()], new_emojis :: [Emoji.t()]}
 
   @doc """
-  Add the member for the given guild from upstream data.
-
-  Return the casted member structure.
-  """
-  @callback member_add(Guild.id(), member :: map()) :: Member.t()
-
-  @doc """
-  Remove the given member for the given guild from upstream data.
-
-  Return the guild ID and old member if the member was cached. Otherwise,
-  return `:noop`.
-  """
-  @callback member_remove(Guild.id(), member :: map()) ::
-              {Guild.id(), old_member :: Member.t()} | :noop
-
-  @doc """
-  Update the given member for the given guild from upstream data.
-
-  Return the guild ID that was updated, the old cached member (if the member
-  was known to the cache), and the updated member.
-
-  ## Note regarding intents
-
-  Even if the required intents to receive `GUILD_MEMBER_UPDATE`
-  events are disabled to a point where we do not receive guild creation events,
-  it is still possible to receive the event for our own user. An example of
-  this can be found in [issue
-  #293](https://github.com/Kraigie/nostrum/issues/293). Note that the linked
-  issue refers to the old contents of this module before the ETS-based guild
-  cache was moved into `#{__MODULE__}.ETS`.
-  """
-  @callback member_update(Guild.id(), member :: map()) ::
-              {Guild.id(), old_member :: Member.t() | nil, updated_member :: Member.t()}
-
-  @doc """
-  Bulk create multiple members in the cache from upstream data.
-
-  Return value is unused, as we currently do not dispatch a gateway for this.
-  """
-  @callback member_chunk(Guild.id(), chunk :: [member :: map()]) :: true
-
-  @doc """
   Create a role on the given guild from upstream data.
 
   Return the casted role.
@@ -291,6 +248,18 @@ defmodule Nostrum.Cache.GuildCache do
   """
   @callback voice_state_update(Guild.id(), state :: map()) :: {Guild.id(), new_state :: [map()]}
 
+  @doc """
+  Increment the member count for this guild by one.
+  """
+  @doc since: "0.7.0"
+  @callback member_count_up(Guild.id()) :: true
+
+  @doc """
+  Decrement the member count for this guild by one.
+  """
+  @doc since: "0.7.0"
+  @callback member_count_down(Guild.id()) :: true
+
   # Dispatching logic.
   defdelegate all, to: @configured_cache
   defdelegate select_all(selector), to: @configured_cache
@@ -313,14 +282,6 @@ defmodule Nostrum.Cache.GuildCache do
   @doc false
   defdelegate emoji_update(guild_id, emojis), to: @configured_cache
   @doc false
-  defdelegate member_add(guild_id, member), to: @configured_cache
-  @doc false
-  defdelegate member_remove(guild_id, member), to: @configured_cache
-  @doc false
-  defdelegate member_update(guild_id, member), to: @configured_cache
-  @doc false
-  defdelegate member_chunk(guild_id, member), to: @configured_cache
-  @doc false
   defdelegate role_create(guild_id, role), to: @configured_cache
   @doc false
   defdelegate role_delete(guild_id, role), to: @configured_cache
@@ -328,6 +289,10 @@ defmodule Nostrum.Cache.GuildCache do
   defdelegate role_update(guild_id, role), to: @configured_cache
   @doc false
   defdelegate voice_state_update(guild_id, state), to: @configured_cache
+  @doc false
+  defdelegate member_count_up(guild_id), to: @configured_cache
+  @doc false
+  defdelegate member_count_down(guild_id), to: @configured_cache
 
   # Helper functions.
 

--- a/lib/nostrum/cache/guild_cache/noop.ex
+++ b/lib/nostrum/cache/guild_cache/noop.ex
@@ -11,7 +11,6 @@ defmodule Nostrum.Cache.GuildCache.NoOp do
   alias Nostrum.Struct.Channel
   alias Nostrum.Struct.Emoji
   alias Nostrum.Struct.Guild
-  alias Nostrum.Struct.Guild.Member
   alias Nostrum.Struct.Guild.Role
   alias Nostrum.Util
   use Supervisor
@@ -76,21 +75,6 @@ defmodule Nostrum.Cache.GuildCache.NoOp do
   end
 
   @impl GuildCache
-  def member_add(_guild_id, member), do: Util.cast(member, {:struct, Member})
-
-  @impl GuildCache
-  def member_update(guild_id, member) do
-    member = Util.cast(member, {:struct, Member})
-    {guild_id, member, member}
-  end
-
-  @impl GuildCache
-  def member_remove(_guild_id, _user_id), do: :noop
-
-  @impl GuildCache
-  def member_chunk(_guild_id, _member_chunk), do: true
-
-  @impl GuildCache
   def role_create(guild_id, role), do: {guild_id, Util.cast(role, {:struct, Role})}
 
   @impl GuildCache
@@ -104,4 +88,10 @@ defmodule Nostrum.Cache.GuildCache.NoOp do
 
   @impl GuildCache
   def voice_state_update(guild_id, _state), do: {guild_id, []}
+
+  @impl GuildCache
+  def member_count_up(_guild_id), do: true
+
+  @impl GuildCache
+  def member_count_down(_guild_id), do: true
 end

--- a/lib/nostrum/cache/member_cache.ex
+++ b/lib/nostrum/cache/member_cache.ex
@@ -1,0 +1,187 @@
+defmodule Nostrum.Cache.MemberCache do
+  @default_cache_implementation Nostrum.Cache.MemberCache.ETS
+  @moduledoc """
+  Cache behaviour & dispatcher for guild members.
+
+  You can call the functions provided by this module independent of which cache
+  is configured, and it will dispatch to the configured cache implementation.
+
+  By default, #{@default_cache_implementation} will be used for caching
+  members. You can override this in the `:caches` option of the `:nostrum`
+  application by setting the `:members` field to a different module
+  implementing the behaviour defined by this module.
+
+  See the documentation for the `Nostrum.Cache.GuildCache` module for more
+  details on how to implement your own.
+  """
+  @moduledoc since: "0.7.0"
+
+  alias Nostrum.Cache.UserCache
+  alias Nostrum.Struct.Guild
+  alias Nostrum.Struct.Guild.Member
+  alias Nostrum.Struct.User
+
+  @configured_cache :nostrum
+                    |> Application.compile_env([:caches, :members], @default_cache_implementation)
+
+  @doc """
+  Get members for a given guild ID.
+
+  The result is returned as a stream to accomodate for large guilds.
+  """
+  @callback get(Guild.id()) :: Enumerable.t(Member.t())
+
+  @doc """
+  Get a single member on the given guild ID.
+
+  The result should be returned as a stream to accomodate for large guilds.
+  """
+  @callback get(Guild.id(), Member.user_id()) :: {:ok, Member.t()} | {:error, atom()}
+
+  @doc """
+  Get all members cached for the given user ID.
+
+  The members will be returned alongside their guild ID as a pair in the
+  format `{guild_id, member}`.
+
+  The result is returned as a stream.
+  """
+  @callback by_user(Member.user_id()) :: Enumerable.t({Guild.id(), Member.t()})
+
+  @doc """
+  Add the member for the given guild from upstream data.
+
+  Return the casted member structure.
+  """
+  @callback create(Guild.id(), member :: map()) :: Member.t()
+
+  @doc """
+  Update the given member for the given guild from upstream data.
+
+  Return the guild ID that was updated, the old cached member (if the member
+  was known to the cache), and the updated member.
+
+  ## Note regarding intents
+
+  Even if the required intents to receive `GUILD_MEMBER_UPDATE` events are
+  disabled to a point where we do not receive guild creation events, it is
+  still possible to receive the event for our own user. An example of this can
+  be found in [issue
+  #293](https://github.com/Kraigie/nostrum/issues/293). Note that the issue
+  predates the modern nostrum caching infrastructure.
+  """
+  @callback update(Guild.id(), member :: map()) ::
+              {Guild.id(), old_member :: Member.t() | nil, updated_member :: Member.t()}
+
+  @doc """
+  Remove the given user for the given guild.
+
+  Return the guild ID and old member if the member was cached. Otherwise,
+  return `:noop`.
+  """
+  @callback delete(Guild.id(), user :: map()) ::
+              {Guild.id(), old_member :: Member.t()} | :noop
+
+  @doc """
+  Bulk create multiple members in the cache from upstream data.
+
+  Return value is unused, as we currently do not dispatch a gateway for this.
+  """
+  @callback bulk_create(Guild.id(), members :: [member :: map()]) :: true
+
+  @doc """
+  Return a query handle for usage with `:qlc`.
+
+  This is used by nostrum to provide automatic joins between the member and the
+  user cache, and may be used for other functions in the future.
+
+  The Erlang manual on [Implementing a QLC
+  Table](https://www.erlang.org/doc/man/qlc.html#implementing_a_qlc_table)
+  contains examples for implementation.
+
+  The query handle must return items in the form `{guild_id, user_id,
+  member}`, where:
+  - `guild_id` is a `t:Nostrum.Struct.Guild.id/0`,
+  - `user_id` is a `t:Nostrum.Struct.User.id/0`, and
+  - `member` is a `t:Nostrum.Struct.Guild.Member.t/0`.
+  """
+  @callback qlc_handle() :: :qlc.query_handle()
+
+  # User-facing
+  defdelegate get(guild_id), to: @configured_cache
+  defdelegate get(guild_id, member_id), to: @configured_cache
+  defdelegate by_user(member_id), to: @configured_cache
+
+  @doc """
+  Return an enumerable of members with their users.
+
+  ## Parameters
+
+  - `guild_id` (`t:Nostrum.Struct.Guild.id/0`): The guild for which to return members.
+
+  ## Return value
+
+  Returns an enumerable that can be consumed with any function in the `Stream`
+  or `Enumerable` module.
+
+  If the user for a guild member is not found, the member and user won't be
+  present in the result. Barring a bug in nostrum's caching, this should never
+  happen in practice.
+  """
+  @spec get_with_users(Guild.id()) :: Enumerable.t({Member.t(), User.t()})
+  def get_with_users(guild_id) do
+    member_query_handle = qlc_handle()
+    user_query_handle = UserCache.qlc_handle()
+    initial_bindings = :erl_eval.new_bindings()
+    member_bindings = :erl_eval.add_binding(:MemberHandle, member_query_handle, initial_bindings)
+    user_bindings = :erl_eval.add_binding(:UserHandle, user_query_handle, member_bindings)
+    final_bindings = :erl_eval.add_binding(:RequestedGuildId, guild_id, user_bindings)
+
+    joined_handle =
+      :qlc.string_to_handle(
+        '[{Member, User} || ' ++
+          '{GuildId, MemberId, Member} <- MemberHandle, ' ++
+          '{UserId, User} <- UserHandle, ' ++
+          'GuildId =:= RequestedGuildId, ' ++
+          'UserId =:= MemberId].',
+        [],
+        final_bindings
+      )
+
+    Stream.resource(
+      fn -> :qlc.cursor(joined_handle) end,
+      fn cursor -> cursor |> :qlc.next_answers(100) |> parse_qlc_answers(cursor) end,
+      fn cursor -> :qlc.delete_cursor(cursor) end
+    )
+  end
+
+  defp parse_qlc_answers([], cursor) do
+    {:halt, cursor}
+  end
+
+  defp parse_qlc_answers(answers, cursor) do
+    parsed_answers = Enum.map(answers, fn {member, user} -> {member, User.to_struct(user)} end)
+    {parsed_answers, cursor}
+  end
+
+  # Nostrum-facing
+  @doc false
+  defdelegate create(guild_id, member), to: @configured_cache
+  @doc false
+  defdelegate delete(guild_id, user), to: @configured_cache
+  @doc false
+  defdelegate update(guild_id, member), to: @configured_cache
+  @doc false
+  defdelegate bulk_create(guild_id, members), to: @configured_cache
+  @doc false
+  defdelegate qlc_handle(), to: @configured_cache
+
+  ## Supervisor callbacks
+  # These set up the backing cache.
+  @doc false
+  defdelegate init(init_arg), to: @configured_cache
+  @doc false
+  defdelegate start_link(init_arg), to: @configured_cache
+  @doc false
+  defdelegate child_spec(opts), to: @configured_cache
+end

--- a/lib/nostrum/cache/member_cache/ets.ex
+++ b/lib/nostrum/cache/member_cache/ets.ex
@@ -1,0 +1,167 @@
+defmodule Nostrum.Cache.MemberCache.ETS do
+  @table_name :nostrum_members
+  @moduledoc """
+  An ETS-based cache for members.
+
+  The supervisor defined by this module will set up the ETS table associated
+  with it.
+
+  The default table name under which guilds are cached is `#{@table_name}`. In
+  addition to the cache behaviour implementations provided by this module, you
+  can also call regular ETS table methods on it, such as `:ets.info`. Use the
+  `tabname/0` function for retrieving the table name at runtime.
+
+  Note that users should not call the functions not related to this specific
+  implementation of the cache directly. Instead, call the functions of
+  `Nostrum.Cache.MemberCache` directly, which will dispatch to the configured
+  cache.
+  """
+  @moduledoc since: "0.7.0"
+
+  @behaviour Nostrum.Cache.MemberCache
+
+  alias Nostrum.Cache.MemberCache
+  alias Nostrum.Struct.Guild
+  alias Nostrum.Struct.Guild.Member
+  alias Nostrum.Util
+  use Supervisor
+
+  @doc "Start the supervisor."
+  def start_link(init_arg) do
+    Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
+  end
+
+  @doc "Set up the cache's ETS table."
+  @impl Supervisor
+  def init(_init_arg) do
+    :ets.new(tabname(), [:set, :public, :named_table])
+    Supervisor.init([], strategy: :one_for_one)
+  end
+
+  @doc "Retrieve the ETS table name used for the cache."
+  @spec tabname :: atom()
+  def tabname, do: @table_name
+
+  # Used by clients
+
+  @doc """
+  Get all members for a given guild ID.
+
+  Note that this implementation uses `:ets.safe_fixtable/2` to ensure safe
+  traversal until the returned stream is exhausted or the calling process
+  terminates. This also degrades performance for other table operations, and
+  prevents table deletions from freeing up memory. It is therefore recommended
+  to finish your business quickly.
+  """
+  @impl MemberCache
+  @spec get(Guild.id()) :: Enumerable.t(Member.t())
+  def get(guild_id) do
+    safe_stream_matchspec([{{{:"$1", :"$2"}, :"$3"}, [{:==, :"$1", guild_id}], [:"$3"]}])
+  end
+
+  @doc "Fetch a single member from the cache."
+  @impl MemberCache
+  @spec get(Guild.id(), Member.user_id()) :: {:ok, Member.t()} | {:error, atom()}
+  def get(guild_id, user_id) do
+    case :ets.lookup(@table_name, {guild_id, user_id}) do
+      [{_key, member}] -> {:ok, member}
+      [] -> {:error, :not_found}
+    end
+  end
+
+  @doc """
+  Get all members for the given user ID.
+
+  The same implementation notes as for `get/1` apply for this function.
+  """
+  @impl MemberCache
+  @spec by_user(Member.user_id()) :: Enumerable.t({Guild.id(), Member.t()})
+  def by_user(user_id) do
+    safe_stream_matchspec([{{{:"$1", :"$2"}, :"$3"}, [{:==, :"$2", user_id}], [{{:"$1", :"$3"}}]}])
+  end
+
+  defp safe_stream_matchspec(ms) do
+    Stream.resource(
+      fn ->
+        :ets.safe_fixtable(@table_name, true)
+        []
+      end,
+      fn
+        [] ->
+          case :ets.select(@table_name, ms, 500) do
+            # Empty table. Bail.
+            :"$end_of_table" -> {:halt, nil}
+            {_matches, _continuation} = result -> result
+          end
+
+        continuation ->
+          case :ets.select(continuation) do
+            # End of table. Bail.
+            :"$end_of_table" -> {:halt, nil}
+            {_matches, _continuation} = result -> result
+          end
+      end,
+      fn _acc ->
+        :ets.safe_fixtable(@table_name, false)
+      end
+    )
+  end
+
+  # Used by dispatch
+
+  @doc "Add the given member to the given guild in the cache."
+  @impl MemberCache
+  @spec create(Guild.id(), map()) :: Member.t()
+  def create(guild_id, payload) do
+    member = Util.cast(payload, {:struct, Member})
+    key = {guild_id, member.user_id}
+    true = :ets.insert(@table_name, {key, member})
+    member
+  end
+
+  @doc "Update the given member for the given guild in the cache."
+  @impl MemberCache
+  @spec update(Guild.id(), map()) :: {Guild.id(), Member.t() | nil, Member.t()}
+  def update(guild_id, payload) do
+    new_member = Util.cast(payload, {:struct, Member})
+
+    case :ets.lookup(@table_name, {guild_id, new_member.user_id}) do
+      [{key, old_member}] ->
+        true = :ets.update_element(@table_name, key, {2, new_member})
+        {guild_id, old_member, new_member}
+
+      [] ->
+        {guild_id, nil, new_member}
+    end
+  end
+
+  @doc "Remove the given member from the given guild in the cache."
+  @impl MemberCache
+  @spec delete(Guild.id(), map()) :: {Guild.id(), Member.t()} | :noop
+  def delete(guild_id, user) do
+    case :ets.take(@table_name, {guild_id, user.id}) do
+      [{{_guild_id, _user_id}, member}] ->
+        {guild_id, member}
+
+      [] ->
+        :noop
+    end
+  end
+
+  @doc "Bulk create a chunk of members for the given guild in the cache."
+  @impl MemberCache
+  def bulk_create(guild_id, members) do
+    # CHONK like that one cat of craig
+    new_members = Enum.map(members, &{{guild_id, &1.user.id}, Util.cast(&1, {:struct, Member})})
+    true = :ets.insert(@table_name, new_members)
+  end
+
+  @doc "Get a QLC handle for the entire table."
+  @doc since: "0.7.0"
+  @impl MemberCache
+  @spec qlc_handle :: :qlc.query_handle()
+  def qlc_handle do
+    unfold_matchspec = [{{{:"$1", :"$2"}, :"$3"}, [], [{{:"$1", :"$2", :"$3"}}]}]
+    :ets.table(@table_name, traverse: {:select, unfold_matchspec})
+  end
+end

--- a/lib/nostrum/cache/user_cache.ex
+++ b/lib/nostrum/cache/user_cache.ex
@@ -81,6 +81,23 @@ defmodule Nostrum.Cache.UserCache do
   """
   @callback delete(snowflake :: User.id()) :: :noop | User.t()
 
+  @doc """
+  Return a query handle for usage with `:qlc`.
+
+  This is used by nostrum to provide automatic joins between the member and the
+  user cache, and may be used for other functions in the future.
+
+  The Erlang manual on [Implementing a QLC
+  Table](https://www.erlang.org/doc/man/qlc.html#implementing_a_qlc_table)
+  contains examples for implementation.
+
+  The query handle must return items in the form `{user_id, user}`, where
+  `user_id` is a `t:Nostrum.Struct.User.id/0` and `user` is a
+  `t:Nostrum.Struct.User.t/0`.
+  """
+  @doc since: "0.7.0"
+  @callback qlc_handle() :: :qlc.query_handle()
+
   ## Dispatching
   defdelegate get(id), to: @configured_cache
   @doc false
@@ -91,6 +108,8 @@ defmodule Nostrum.Cache.UserCache do
   defdelegate update(payload), to: @configured_cache
   @doc false
   defdelegate delete(snowflake), to: @configured_cache
+  @doc false
+  defdelegate qlc_handle(), to: @configured_cache
 
   @doc """
   Same as `c:get/1`, but raises `Nostrum.Error.CacheError` in case of a failure.

--- a/lib/nostrum/cache/user_cache/ets.ex
+++ b/lib/nostrum/cache/user_cache/ets.ex
@@ -58,6 +58,14 @@ defmodule Nostrum.Cache.UserCache.ETS do
     end
   end
 
+  @doc "Get a QLC handle for the backing table."
+  @doc since: "0.7.0"
+  @impl Nostrum.Cache.UserCache
+  @spec qlc_handle :: :qlc.query_handle()
+  def qlc_handle do
+    :ets.table(@table_name)
+  end
+
   @doc "Get a user by ID."
   @impl Nostrum.Cache.UserCache
   @spec get(User.id()) :: {:ok, User.t()} | {:error, atom}

--- a/lib/nostrum/struct/guild.ex
+++ b/lib/nostrum/struct/guild.ex
@@ -6,7 +6,6 @@ defmodule Nostrum.Struct.Guild do
     :unavailable,
     :member_count,
     :voice_states,
-    :members,
     :channels,
     :guild_scheduled_events,
     :threads
@@ -17,7 +16,7 @@ defmodule Nostrum.Struct.Guild do
   """
 
   alias Nostrum.Struct.{Channel, Emoji, User}
-  alias Nostrum.Struct.Guild.{Member, Role, ScheduledEvent}
+  alias Nostrum.Struct.Guild.{Role, ScheduledEvent}
   alias Nostrum.{Constants, Snowflake, Util}
 
   defstruct [
@@ -47,7 +46,6 @@ defmodule Nostrum.Struct.Guild do
     :unavailable,
     :member_count,
     :voice_states,
-    :members,
     :channels,
     :guild_scheduled_events,
     :vanity_url_code,
@@ -150,9 +148,6 @@ defmodule Nostrum.Struct.Guild do
   @typedoc "List of voice states as maps"
   @type voice_states :: list(map) | nil
 
-  @typedoc "List of members"
-  @type members :: %{required(User.id()) => Member.t()} | nil
-
   @typedoc "List of channels"
   @type channels :: %{required(Channel.id()) => Channel.t()} | nil
 
@@ -196,7 +191,6 @@ defmodule Nostrum.Struct.Guild do
           unavailable: nil,
           member_count: nil,
           voice_states: nil,
-          members: nil,
           channels: nil,
           vanity_url_code: nil,
           threads: nil
@@ -233,7 +227,6 @@ defmodule Nostrum.Struct.Guild do
           unavailable: nil,
           member_count: nil,
           voice_states: nil,
-          members: nil,
           channels: nil,
           guild_scheduled_events: nil,
           threads: nil
@@ -269,7 +262,6 @@ defmodule Nostrum.Struct.Guild do
           unavailable: true,
           member_count: nil,
           voice_states: nil,
-          members: nil,
           channels: nil,
           guild_scheduled_events: nil,
           vanity_url_code: nil,
@@ -306,7 +298,6 @@ defmodule Nostrum.Struct.Guild do
           unavailable: false,
           member_count: member_count,
           voice_states: voice_states,
-          members: members,
           channels: channels,
           guild_scheduled_events: guild_scheduled_events,
           vanity_url_code: vanity_url_code,
@@ -393,7 +384,6 @@ defmodule Nostrum.Struct.Guild do
       |> Map.update(:system_channel_id, nil, &Util.cast(&1, Snowflake))
       |> Map.update(:rules_channel_id, nil, &Util.cast(&1, Snowflake))
       |> Map.update(:public_updates_channel_id, nil, &Util.cast(&1, Snowflake))
-      |> Map.update(:members, nil, &Util.cast(&1, {:index, [:user, :id], {:struct, Member}}))
       |> Map.update(:channels, nil, &Util.cast(&1, {:index, [:id], {:struct, Channel}}))
       |> Map.update(:joined_at, nil, &Util.maybe_to_datetime/1)
       |> Map.update(

--- a/lib/nostrum/struct/guild/member.ex
+++ b/lib/nostrum/struct/guild/member.ex
@@ -11,11 +11,11 @@ defmodule Nostrum.Struct.Guild.Member do
   protocol or `mention/1`.
 
   ```elixir
-  member = %Nostrum.Struct.Guild.Member{user: Nostrum.Struct.User{id: 120571255635181568}}
+  member = %Nostrum.Struct.Guild.Member{user_id: 120571255635181568}
   Nostrum.Api.create_message!(184046599834435585, "#{member}")
   %Nostrum.Struct.Message{content: "<@120571255635181568>"}
 
-  member = %Nostrum.Struct.Guild.Member{user: Nostrum.Struct.User{id: 89918932789497856}}
+  member = %Nostrum.Struct.Guild.Member{user_id: 89918932789497856}
   Nostrum.Api.create_message!(280085880452939778, "#{Nostrum.Struct.Guild.Member.mention(member)}")
   %Nostrum.Struct.Message{content: "<@89918932789497856>"}
   ```
@@ -28,7 +28,7 @@ defmodule Nostrum.Struct.Guild.Member do
   import Bitwise
 
   defstruct [
-    :user,
+    :user_id,
     :nick,
     :roles,
     :joined_at,
@@ -43,47 +43,58 @@ defmodule Nostrum.Struct.Guild.Member do
   end
 
   @typedoc """
-  The user struct. This field can be `nil` if the Member struct came as a partial Member object included
-  in a message received from a guild channel.
-  """
-  @type user :: User.t() | nil
+  The user ID.
 
-  @typedoc "The nickname of the user"
+  This field can be `nil` if the Member struct came as a partial Member object
+  included in a message received from a guild channel. To retrieve the user
+  object, use `Nostrum.Cache.UserCache`.
+  """
+  @type user_id :: User.id() | nil
+
+  @typedoc "The nickname of the member"
   @type nick :: String.t() | nil
 
   @typedoc "A list of role ids"
   @type roles :: [Role.id()]
 
   @typedoc """
-  Date the user joined the guild.
+  Date the member joined the guild.
   If you dont request offline guild members this field will be `nil` for any members that come online.
   """
   @type joined_at :: String.t() | nil
 
   @typedoc """
-  Whether the user is deafened.
+  Whether the member is deafened.
   If you dont request offline guild members this field will be `nil` for any members that come online.
   """
   @type deaf :: boolean | nil
 
   @typedoc """
-  Whether the user is muted.
+  Whether the member is muted.
   If you dont request offline guild members this field will be `nil` for any members that come online.
   """
   @type mute :: boolean | nil
 
   @typedoc """
-  Current timeout status of the user. If user is currently timed out this will be a `t:DateTime.t/0` of the unmute time, it will be `nil` or a date in the past if the user is not currently timed out.
+  Current timeout status of the member.
+
+  If member is currently timed out this will be a `t:DateTime.t/0` of the
+  unmute time, it will be `nil` or a date in the past if the member is not
+  currently timed out.
   """
   @type communication_disabled_until :: DateTime.t() | nil
 
   @typedoc """
-  Current guild booster status of the user. If user is currently boosting a guild this will be a `t:DateTime.t/0` since the start of the boosting, it will be `nil` if the user is not currently boosting the guild.
+  Current guild booster status of the member.
+
+  If member is currently boosting a guild this will be a `t:DateTime.t/0` since
+  the start of the boosting, it will be `nil` if the member is not currently
+  boosting the guild.
   """
   @type premium_since :: DateTime.t() | nil
 
   @type t :: %__MODULE__{
-          user: user,
+          user_id: user_id,
           nick: nick,
           roles: roles,
           joined_at: joined_at,
@@ -99,13 +110,15 @@ defmodule Nostrum.Struct.Guild.Member do
   ## Examples
 
   ```elixir
-  iex> member = %Nostrum.Struct.Guild.Member{user: %Nostrum.Struct.User{id: 177888205536886784}}
+  iex> member = %Nostrum.Struct.Guild.Member{user_id: 177888205536886784}
   ...> Nostrum.Struct.Guild.Member.mention(member)
   "<@177888205536886784>"
   ```
   """
   @spec mention(t) :: String.t()
-  def mention(%__MODULE__{user: user}), do: User.mention(user)
+  def mention(%__MODULE__{user_id: user_id}) do
+    "<@#{user_id}>"
+  end
 
   @doc """
   Returns a member's guild permissions.
@@ -122,8 +135,8 @@ defmodule Nostrum.Struct.Guild.Member do
   @spec guild_permissions(t, Guild.t()) :: [Permission.t()]
   def guild_permissions(member, guild)
 
-  def guild_permissions(%__MODULE__{user: %{id: user_id}}, %Guild{owner_id: owner_id})
-      when user_id === owner_id,
+  def guild_permissions(%__MODULE__{user_id: owner_id}, %Guild{owner_id: owner_id})
+      when owner_id != nil,
       do: Permission.all()
 
   def guild_permissions(%__MODULE__{} = member, %Guild{} = guild) do
@@ -170,7 +183,7 @@ defmodule Nostrum.Struct.Guild.Member do
 
       everyone_role_id = guild.id
       role_ids = [everyone_role_id | member.roles]
-      overwrite_ids = role_ids ++ [member.user.id]
+      overwrite_ids = role_ids ++ [member.user_id]
 
       {allow, deny} =
         channel.permission_overwrites
@@ -215,21 +228,15 @@ defmodule Nostrum.Struct.Guild.Member do
   end
 
   @doc false
-  def p_encode do
-    %__MODULE__{
-      user: User.p_encode()
-    }
-  end
-
-  @doc false
   def to_struct(map) do
     new =
       map
       |> Map.new(fn {k, v} -> {Util.maybe_to_atom(k), v} end)
-      |> Map.update(:user, nil, &Util.cast(&1, {:struct, User}))
       |> Map.update(:roles, nil, &Util.cast(&1, {:list, Snowflake}))
       |> Map.update(:communication_disabled_until, nil, &Util.maybe_to_datetime/1)
       |> Map.update(:premium_since, nil, &Util.maybe_to_datetime/1)
+      |> Map.update(:joined_at, nil, &Util.maybe_to_unixtime/1)
+      |> Map.put(:user_id, Util.cast(map[:user][:id], Snowflake))
 
     struct(__MODULE__, new)
   end

--- a/lib/nostrum/util.ex
+++ b/lib/nostrum/util.ex
@@ -181,6 +181,20 @@ defmodule Nostrum.Util do
     casted
   end
 
+  @doc """
+  Converts possibly nil ISO8601 timestamp to unix time.
+  """
+  @spec maybe_to_unixtime(String.t() | nil) :: pos_integer() | nil
+  def maybe_to_unixtime(nil) do
+    nil
+  end
+
+  def maybe_to_unixtime(stamp) do
+    stamp
+    |> maybe_to_datetime()
+    |> DateTime.to_unix()
+  end
+
   # Generic casting function
   @doc false
   @spec cast(term, module | {:list, term} | {:struct, term} | {:index, [term], term}) :: term

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Nostrum.Mixfile do
   def project do
     [
       app: :nostrum,
-      version: "0.6.1",
+      version: "0.7.0",
       elixir: "~> 1.11",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,

--- a/test/nostrum/cache/member_cache_test.exs
+++ b/test/nostrum/cache/member_cache_test.exs
@@ -1,0 +1,96 @@
+defmodule Nostrum.Cache.MemberCacheTest do
+  alias Nostrum.Cache.MemberCache
+  alias Nostrum.Cache.UserCache
+  alias Nostrum.Struct.Guild.Member
+  use ExUnit.Case
+
+  @moduledoc since: "0.7.0"
+
+  @cache_modules [
+    # Implementations
+    Nostrum.Cache.MemberCache.ETS
+  ]
+
+  describe "get_with_users/1" do
+    setup do
+      [member_pid: start_supervised!(MemberCache), user_pid: start_supervised!(UserCache)]
+    end
+
+    test "with unknown guild" do
+      assert [] = Enum.to_list(MemberCache.get_with_users(1_298_414))
+    end
+
+    test "guild with users" do
+      guild_id = 123_890_195
+      user_id = 128_309_125
+      user = %{id: user_id, username: "joe"}
+      member = %{user: user}
+      assert created_user = UserCache.create(user)
+      assert created_member = MemberCache.create(guild_id, member)
+
+      stream = MemberCache.get_with_users(guild_id)
+      assert [{^created_member, ^created_user}] = Enum.to_list(stream)
+    end
+  end
+
+  for cache <- @cache_modules do
+    defmodule :"#{cache}Test" do
+      use ExUnit.Case
+      # this is needed because otherwise we cannot access
+      # the cache in the tests
+      @cache cache
+      @test_guild_id 12409
+      @test_member %{
+        nickname: "Joe",
+        roles: [],
+        user_id: 120_391
+      }
+
+      doctest @cache
+
+      setup do
+        [pid: start_supervised!(@cache)]
+      end
+
+      test "member management" do
+        # create/2
+        # the gateway sends this differently, let's change it
+        {user_id, raw} = Map.pop(@test_member, :user_id)
+        as_payload = Map.put(raw, :user, %{id: user_id})
+        expected = Member.to_struct(as_payload)
+        member = @cache.create(@test_guild_id, as_payload)
+        assert ^expected = member
+
+        assert {:ok, ^member} = @cache.get(@test_guild_id, @test_member.user_id)
+
+        # update/2
+        payload = %{as_payload | nickname: "GrumblerBot3"}
+        updated = Member.to_struct(payload)
+        {guild_id, ^expected, ^updated} = @cache.update(@test_guild_id, payload)
+        assert guild_id == @test_guild_id
+
+        assert {:ok, ^member} = @cache.get(@test_guild_id, @test_member.user_id)
+
+        # delete/2
+        remove_payload = %{id: @test_member.user_id}
+        {^guild_id, ^updated} = @cache.delete(@test_guild_id, remove_payload)
+        guild_members = @cache.get(@test_guild_id)
+        assert Enum.empty?(guild_members)
+      end
+
+      test "bulk_create/2" do
+        # bulk_create receives the raw gateway-provided
+        # member objects, which include the user.
+        first_member = Map.put(@test_member, :user, %{id: @test_member.user_id})
+        second_member = Map.put(%{@test_member | user_id: 12058}, :user, %{id: 12058})
+        chunk = [first_member, second_member]
+        casted_first_member = Member.to_struct(first_member)
+        casted_second_member = Member.to_struct(second_member)
+        assert true = @cache.bulk_create(@test_guild_id, chunk)
+
+        members = Enum.sort(@cache.get(@test_guild_id), &(&1.user_id >= &2.user_id))
+        assert [^casted_first_member, ^casted_second_member] = members
+      end
+    end
+  end
+end

--- a/test/nostrum/struct/guild/member_test.exs
+++ b/test/nostrum/struct/guild/member_test.exs
@@ -9,9 +9,10 @@ defmodule Nostrum.Struct.MemberTest do
 
   describe "mention/1" do
     test "matches `Nostrum.Struct.User.mention/1`" do
-      member = %Member{user: %User{id: 150_061_853_001_777_154}}
+      member = %Member{user_id: 150_061_853_001_777_154}
+      user = %User{id: member.user_id}
 
-      assert(Member.mention(member) === User.mention(member.user))
+      assert(Member.mention(member) === User.mention(user))
     end
   end
 
@@ -23,16 +24,16 @@ defmodule Nostrum.Struct.MemberTest do
 
       result = Member.guild_permissions(member, guild)
 
-      assert(result === Permission.all())
+      assert result === Permission.all()
     end
 
     test "returns all perms if owner" do
-      member = %Member{user: %User{id: 200}}
-      guild = %Guild{owner_id: 200}
+      member = %Member{user_id: 200}
+      guild = %Guild{owner_id: member.user_id}
 
       result = Member.guild_permissions(member, guild)
 
-      assert(result === Permission.all())
+      assert result === Permission.all()
     end
 
     test "returns permissions otherwise" do
@@ -46,7 +47,7 @@ defmodule Nostrum.Struct.MemberTest do
 
       result = Member.guild_permissions(member, guild)
 
-      assert(result === Permission.from_bitset(0x00000021))
+      assert result === Permission.from_bitset(0x00000021)
     end
   end
 
@@ -62,13 +63,12 @@ defmodule Nostrum.Struct.MemberTest do
     end
 
     test "returns all perms if member is admin", context do
-      member = %Member{user: %User{id: context[:member_id]}, roles: [context[:role_id]]}
+      member = %Member{user_id: context[:member_id], roles: [context[:role_id]]}
       role = %Role{id: context[:role_id], permissions: 0x00000008}
       channel = %Channel{id: context[:channel_id]}
 
       guild = %Guild{
         channels: %{channel.id => channel},
-        members: %{member.user.id => member},
         roles: %{role.id => role}
       }
 
@@ -81,7 +81,7 @@ defmodule Nostrum.Struct.MemberTest do
       test_perm_bits = 0x00000040
 
       member = %Member{
-        user: %User{id: context[:member_id]},
+        user_id: context[:member_id],
         roles: [context[:everyone_role_id], context[:role_id]]
       }
 
@@ -110,7 +110,7 @@ defmodule Nostrum.Struct.MemberTest do
     test "member overwrites have priority over role overwrites", context do
       test_perm_bits = 0x00000040
 
-      member = %Member{user: %User{id: context[:member_id]}, roles: [context[:role_id]]}
+      member = %Member{user_id: context[:member_id], roles: [context[:role_id]]}
 
       everyone_role = %Role{id: context[:everyone_role_id], permissions: 0}
       role = %Role{id: context[:role_id], permissions: 0}
@@ -136,7 +136,7 @@ defmodule Nostrum.Struct.MemberTest do
 
     test "returns empty list when there are no matching ids between channel overrides and member roles",
          context do
-      member = %Member{user: %User{id: context[:member_id]}, roles: [context[:role_id]]}
+      member = %Member{user_id: context[:member_id], roles: [context[:role_id]]}
 
       everyone_role = %Role{id: context[:everyone_role_id], permissions: 0}
       role = %Role{id: context[:role_id], permissions: 0}
@@ -193,9 +193,16 @@ defmodule Nostrum.Struct.MemberTest do
 
   describe "String.Chars" do
     test "matches `mention/1`" do
-      member = %Member{user: %User{id: 150_061_853_001_777_154}}
+      member = %Member{user_id: 150_061_853_001_777_154}
 
-      assert(to_string(member) === Member.mention(member))
+      assert to_string(member) === Member.mention(member)
+    end
+  end
+
+  describe "to_struct/1" do
+    test "casts string snowflakes" do
+      data = %{user: %{id: "1234"}}
+      assert %Member{user_id: 1234} = Member.to_struct(data)
     end
   end
 end

--- a/test/nostrum/struct/interaction_test.exs
+++ b/test/nostrum/struct/interaction_test.exs
@@ -51,11 +51,11 @@ defmodule Nostrum.Struct.InteractionTest do
       "premium_since" => nil,
       "roles" => [451_824_750_399_062_036, 458_692_275_199_803_406],
       "user" => %{
-        "avatar" => "d52bf0e27ed56fcde93f8ee345ba8977",
-        "discriminator" => "2359",
-        "id" => 196_989_358_165_852_114,
+        "avatar" => "deadbeef",
+        "discriminator" => "1234",
+        "id" => 149_120,
         "public_flags" => 0,
-        "username" => "Volcyy"
+        "username" => "Joe Armstrong"
       }
     },
     "token" => "bob",
@@ -94,7 +94,7 @@ defmodule Nostrum.Struct.InteractionTest do
                guild_id: 451_824_027_976_073_216,
                id: 857_721_405_302_112_276,
                member: %Member{
-                 user: %User{}
+                 user_id: 149_120
                },
                user: %User{},
                token: "bob",


### PR DESCRIPTION
This is a breaking change. Library users need to migrate any usages of `guild.members` and `member.user` as appropriate. The below message shares some details.

This patch is mainly intended to allow nostrum to function properly on large guilds, especially in respect to memory usage with `request_guild_members: true`, and introduces two big changes:

- Members are no longer stored on guilds: if somebody wants to find the members of a given guild, the `MemberCache.get/1` function should be used. This returns a stream of members and as such can be safely used on larger guilds.

- Users are no longer stored on members. This prevents duplicating information that nostrum needs to update multiple times, and helps reduce memory usage. If the users for specific members should be looked up, the `MemberCache.get_with_users/1` function should be used. This internally performs a join of the member and user caches via `:qlc`.

To support these new APIs, the `c:UserCache.qlc_handle/0` and `c:MemberCache.qlc_handle/0` callbacks have been introduced. If not using `:ets` (such as with the default cache), `:dets` or `:mnesia` (if implementing a custom cache), documentation for implementing your own is linked in the behaviour. Future versions of nostrum may introduce ways to override this function in individual caches to allow for more efficient joins. It should however be noted that the current architecture is intentionally built to allow switching the caching backend around.