### PR TITLE
Document inline event awaiting

### DIFF
--- a/lib/nostrum/consumer.ex
+++ b/lib/nostrum/consumer.ex
@@ -69,7 +69,7 @@ defmodule Nostrum.Consumer do
 
   For example, a message create will look like this
   ```elixir
-  {:MESSAGE_CREATE, {Nostrum.Struct.Message.t}, WSState.t}
+  {:MESSAGE_CREATE, Nostrum.Struct.Message.t, WSState.t}
   ```
 
   In some cases there will be multiple payloads when something is updated, so as
@@ -375,7 +375,7 @@ defmodule Nostrum.Consumer do
         }
       end
 
-      def handle_cast({:event, event}, state) do
+      def handle_info({:event, event}, state) do
         Task.start_link(fn ->
           __MODULE__.handle_event(event)
         end)

--- a/test/nostrum/consumer_group_test.exs
+++ b/test/nostrum/consumer_group_test.exs
@@ -1,0 +1,18 @@
+defmodule Nostrum.ConsumerGroupTest do
+  alias Nostrum.ConsumerGroup
+  alias Nostrum.Struct.Message
+  use ExUnit.Case
+
+  setup_all do
+    [pid: start_supervised!(ConsumerGroup)]
+  end
+
+  describe "inline awaiting" do
+    test "forwards messages to the subscriber" do
+      :ok = ConsumerGroup.join()
+      message = %Message{content: "craig's cat"}
+      :ok = ConsumerGroup.dispatch({:MESSAGE_CREATE, message})
+      assert_receive {:event, {:MESSAGE_CREATE, ^message}}
+    end
+  end
+end


### PR DESCRIPTION
This is relatively crude at the moment, and may not scale well for the case where the subscribing process is long-lived and lots of gateway events come in. For that, we should introduce a specialized function that adds a matcher. For a start, this is sufficient.

Fixes #316.