### PR TITLE
Optimize mnesia cache querying

### DIFF
--- a/lib/nostrum/cache/guild_cache/mnesia.ex
+++ b/lib/nostrum/cache/guild_cache/mnesia.ex
@@ -291,7 +291,20 @@ if Code.ensure_loaded?(:mnesia) do
     @doc "Get a QLC handle for the guild cache."
     @spec query_handle :: :qlc.query_handle()
     def query_handle do
-      ms = [{{:_, :"$1", :"$2"}, [], [{{:"$1", :"$2"}}]}]
+      query_handle([])
+    end
+
+    @doc """
+    Retrieve a query handle for the table with optional match specification guards.
+
+    ## Match specification variables
+
+    - `$1`: The guild ID
+    - `$2` The guild object itself
+    """
+    @doc since: "0.10.0"
+    def query_handle(guards) do
+      ms = [{{:_, :"$1", :"$2"}, guards, [{{:"$1", :"$2"}}]}]
       :mnesia.table(@table_name, {:traverse, {:select, ms}})
     end
 

--- a/lib/nostrum/cache/member_cache/mnesia.ex
+++ b/lib/nostrum/cache/member_cache/mnesia.ex
@@ -147,7 +147,23 @@ if Code.ensure_loaded?(:mnesia) do
     @doc "Get a QLC query handle for the member cache."
     @spec query_handle :: :qlc.query_handle()
     def query_handle do
-      :mnesia.table(@table_name)
+      query_handle([])
+    end
+
+    @doc """
+    Retrieve a query handle for the table with optional match specification guards.
+
+    ## Match specification variables
+
+    - `$1`: The guild ID the presence is stored on
+    - `$2`: The user associated with the presence
+    - `$3`: The member itself
+    """
+    @doc since: "0.10.0"
+    @spec query_handle([term()]) :: :qlc.query_handle()
+    def query_handle(guards) do
+      ms = [{{_name = :_, _key = :_, :"$1", :"$2", :"$3"}, guards, [{{{{:"$1", :"$2"}}, :"$3"}}]}]
+      :mnesia.table(@table_name, {:traverse, {:select, ms}})
     end
 
     @impl MemberCache

--- a/lib/nostrum/cache/presence_cache/mnesia.ex
+++ b/lib/nostrum/cache/presence_cache/mnesia.ex
@@ -100,8 +100,22 @@ if Code.ensure_loaded?(:mnesia) do
     @doc since: "0.8.0"
     @spec query_handle :: :qlc.query_handle()
     def query_handle do
-      # Note: :"$1" holds a pair here (`{guild_id, user_id}`).
-      ms = [{{:_, :"$1", :"$2"}, [], [{{:"$1", :"$2"}}]}]
+      query_handle([])
+    end
+
+    @doc """
+    Retrieve a query handle for the table with optional match specification guards.
+
+    ## Match specification variables
+
+    - `$1`: The guild ID the presence is stored on
+    - `$2`: The user associated with the presence
+    - `$3`: The user presence itself
+    """
+    @doc since: "0.10.0"
+    @spec query_handle([term()]) :: :qlc.query_handle()
+    def query_handle(guards) do
+      ms = [{{:_, {:"$1", :"$2"}, :"$3"}, guards, [{{{{:"$1", :"$2"}}, :"$3"}}]}]
       :mnesia.table(@table_name, {:traverse, {:select, ms}})
     end
 

--- a/src/nostrum_guild_cache_qlc.erl
+++ b/src/nostrum_guild_cache_qlc.erl
@@ -10,5 +10,9 @@ all(Cache) ->
 
 
 get(RequestedGuildId, Cache) ->
-    qlc:q([Guild || {GuildId, Guild} <- Cache:query_handle(),
+    QH = case erlang:function_exported(Cache, query_handle, 1) of
+             true -> Cache:query_handle([{'==', '$1', {const, RequestedGuildId}}]);
+             false -> Cache:query_handle()
+         end,
+    qlc:q([Guild || {GuildId, Guild} <- QH,
                     GuildId =:= RequestedGuildId]).

--- a/src/nostrum_presence_cache_qlc.erl
+++ b/src/nostrum_presence_cache_qlc.erl
@@ -6,6 +6,14 @@
 % Optimized presence cache QLC queries.
 
 get(RequestedGuildId, RequestedUserId, Cache) ->
-    qlc:q([Presence || {{GuildId, UserId}, Presence} <- Cache:query_handle(),
+    QH = case erlang:function_exported(Cache, query_handle, 1) of
+             true ->
+                 Guards = [{'==', '$1', {const, RequestedGuildId}},
+                           {'==', '$2', {const, RequestedUserId}}],
+                 Cache:query_handle(Guards);
+             false ->
+                 Cache:query_handle()
+         end,
+    qlc:q([Presence || {{GuildId, UserId}, Presence} <- QH,
                                    GuildId =:= RequestedGuildId,
                                    UserId =:= RequestedUserId]).


### PR DESCRIPTION
QLC queries via mnesia-based caches that would use the `{traverse, {select, MatchSpec}}` in any shape or form would cause the QLC query to be executed in two parts, the `mnesia:table` call running the entire table over the selected match specification, and then another Erlang list comprehension that would filter the results of that across a list comprehension in plain Erlang. Per the discussion in #622, this is how such a query would look like under `qlc:info/1`:

    qlc:q([
           Guild ||
               {GuildId, Guild} <-
                   mnesia:table(nostrum_guilds,
                                [{n_objects, 100},
                                 {lock, read} |
                                 {traverse,
                                  {select,
                                   [{{'_', '$1', '$2'},
                                     [],
                                     [{{'$1', '$2'}}]}]}}]),
               GuildId =:= RequestedGuildId
          ])

The issue is that neither QLC nor mnesia can cleanly optimize it here: Mnesia does not know about the condition specified in QLC, and QLC's optimization to use a `lookup_fun` is knocked out by the fact that it can't reach into the traverse call to detect the reordered columns. It might be possible to implement this in QLC itself, given it is smart enough to figure out when to use the lookup function based on the indices, together with some cooperation from Mnesia itself. Obviously, this behaviour would lead to unacceptable performance.

This commit introduces an optimization that allows guild, member and presence cache implementations to export a `query_handle/1` function that accepts a match specification guard, that is, the "middle part" of a match specification. The guard determines which rows shall be filtered. Do note, however, that this is still unable to perform a complete optimization of lookups of single records - it will still traverse the table, but in the native ETS code.