### PR TITLE
fix `@spec` for `Nostrum.Voice.get_channel_id/1` to include possible `nil`

### DIFF
--- a/lib/nostrum/voice.ex
+++ b/lib/nostrum/voice.ex
@@ -564,7 +564,7 @@ defmodule Nostrum.Voice do
   nil
   ```
   """
-  @spec get_channel_id(Guild.id()) :: Channel.id()
+  @spec get_channel_id(Guild.id()) :: Channel.id() | nil
   def get_channel_id(guild_id) do
     voice = get_voice(guild_id)
     if voice, do: voice.channel_id


### PR DESCRIPTION
https://github.com/Kraigie/nostrum/blob/5d5212d72feb2a4b78391a6297bf05f1937ee070/lib/nostrum/voice.ex#L567-L571

According to the documentation
https://github.com/Kraigie/nostrum/blob/5d5212d72feb2a4b78391a6297bf05f1937ee070/lib/nostrum/voice.ex#L551

However, contrary to the documentation & to actual behavior, the return in the `@spec` does not include `nil` and thus warns in a common use case such as
```elixir
case Voice.get_channel_id(guild_id) do
  nil ->
    Api.Interaction.create_response(
      interaction,
      Response.build_simple("> Error: Bot not in a voice channel")
    )

  voice_channel_id ->
    Voice.leave_channel(guild_id)

    Api.Interaction.create_response(
      interaction,
      Response.build_simple("Joined voice channel: <##{voice_channel_id}>")
    )
end
```

Dialyzer spits out (on the `nil ->` line):
```
1. The pattern can never match the type.
   
   Pattern:
   nil
   
   Type:
   non_neg_integer()
```