### PR TITLE
Added locale type & helper function

### DIFF
--- a/lib/nostrum/locale.ex
+++ b/lib/nostrum/locale.ex
@@ -40,7 +40,7 @@ defmodule Nostrum.Locale do
     :ko
   ]
 
-  # NOTE To avoid maintaining a duplicate list & type. Builds a union via AST from @locales.
+  # NOTE Builds a union via AST from @locales to avoid maintaining a duplicate list & type.
   @type t ::
           unquote(
             Enum.reduce(


### PR DESCRIPTION
Locales are now a more important part of Discord API use, since they are used for some of the new application command fields ([`guild_locale?`, `name_localizations?`, and `description_localizations?`](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-structure)).

This provides similar typing options and converter functionality to `Nostrum.Permission`. 

There's some meta-programming happening to construct the type via AST from a list. This is to make sure there's only one source of truth for the locale list.

I haven't touched any business logic for creating application commands yet, where this will be used. I wanted to get some feedback first :) I'm also thinking it might be good to be explicit about some of the [newer application commands fields](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-structure), as although they work right now, they're not handled by the structs.