### PR TITLE
Bump min salchicha to 0.5

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -178,7 +178,7 @@ defmodule Nostrum.Mixfile do
       # Replacement for Jason, remove once we required OTP 27+
       # {:json_polyfill, "~> 0.2"},
       {:gun, "~> 2.0"},
-      {:salchicha, "~> 0.3"},
+      {:salchicha, "~> 0.5"},
       {:certifi, "~> 2.13"},
       {:mime, "~> 1.6 or ~> 2.0"},
       {:ezstd, "~> 1.1", optional: true},

--- a/mix.lock
+++ b/mix.lock
@@ -21,7 +21,7 @@
   "mime": {:hex, :mime, "2.0.6", "8f18486773d9b15f95f4f4f1e39b710045fa1de891fada4516559967276e4dc2", [:mix], [], "hexpm", "c9945363a6b26d747389aac3643f8e0e09d30499a138ad64fe8fd1d13d9b153e"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.4.2", "8efba0122db06df95bfaa78f791344a89352ba04baedd3849593bfce4d0dc1c6", [:mix], [], "hexpm", "4b21398942dda052b403bbe1da991ccd03a053668d147d53fb8c4e0efe09c973"},
   "recon": {:hex, :recon, "2.5.6", "9052588e83bfedfd9b72e1034532aee2a5369d9d9343b61aeb7fbce761010741", [:mix, :rebar3], [], "hexpm", "96c6799792d735cc0f0fd0f86267e9d351e63339cbe03df9d162010cefc26bb0"},
-  "salchicha": {:hex, :salchicha, "0.3.0", "7c153a6353ef9abb9aad03dba3e05732a164315d3d66c507fcf327ca22241acb", [:mix], [], "hexpm", "a7d72601b66b057b988606ea8524d8c4bca9deab0040d7b2533ad44ed809f9e9"},
+  "salchicha": {:hex, :salchicha, "0.5.0", "b05b404550b433494fce1abdb23314afa1f1c72aef898f2c77de6554cf58235e", [:mix], [], "hexpm", "b3e0575cd5a01672d9cefc4ec50bd56662a4d970e2ae39d8de6cf82f09012fc8"},
   "sourceror": {:hex, :sourceror, "1.7.1", "599d78f4cc2be7d55c9c4fd0a8d772fd0478e3a50e726697c20d13d02aa056d4", [:mix], [], "hexpm", "cd6f268fe29fa00afbc535e215158680a0662b357dc784646d7dff28ac65a0fc"},
   "statistex": {:hex, :statistex, "1.0.0", "f3dc93f3c0c6c92e5f291704cf62b99b553253d7969e9a5fa713e5481cd858a5", [:mix], [], "hexpm", "ff9d8bee7035028ab4742ff52fc80a2aa35cece833cf5319009b52f1b5a86c27"},
   "telemetry": {:hex, :telemetry, "1.3.0", "fedebbae410d715cf8e7062c96a1ef32ec22e764197f70cda73d82778d61e7a2", [:rebar3], [], "hexpm", "7015fc8919dbe63764f4b4b87a95b7c0996bd539e0d499be6ec9d7f3875b79e6"},


### PR DESCRIPTION
Version 0.5.0 has up to ~3.1x reduced memory usage and ~1.6x increased speed compared to previous versions for Salsa and ChaCha modes