### PR TITLE
Added guild member counts 

### DIFF
--- a/lib/nostrum/api/guild.ex
+++ b/lib/nostrum/api/guild.ex
@@ -332,6 +332,10 @@ defmodule Nostrum.Api.Guild do
 
   If successful, returns `{:ok, guild}`. Otherwise, returns a `t:Nostrum.Api.error/0`.
 
+  ## Options
+
+    * `:with_counts` (boolean) - include approximate member and presence counts in response
+
   ## Examples
 
   ```elixir
@@ -339,9 +343,13 @@ defmodule Nostrum.Api.Guild do
   {:ok, %Nostrum.Struct.Guild{id: 81384788765712384}}
   ```
   """
-  @spec get(Guild.id()) :: Api.error() | {:ok, Guild.rest_guild()}
-  def get(guild_id) when is_snowflake(guild_id) do
-    Api.request(:get, Constants.guild(guild_id))
+  @spec get(Guild.id(), Api.options()) :: Api.error() | {:ok, Guild.rest_guild()}
+  def get(guild_id, options \\ [])
+
+  def get(guild_id, options) when is_list(options), do: get(guild_id, Map.new(options))
+
+  def get(guild_id, options) when is_snowflake(guild_id) and is_map(options) do
+    Api.request(:get, Constants.guild(guild_id), "", options)
     |> Helpers.handle_request_with_decode({:struct, Guild})
   end
 

--- a/lib/nostrum/api/self.ex
+++ b/lib/nostrum/api/self.ex
@@ -152,7 +152,8 @@ defmodule Nostrum.Api.Self do
     guild ID
     * `:after` (`t:Nostrum.Snowflake.t/0`) - get guilds after this guild
     ID
-    * `:limit` (integer) - max number of guilds to return (1-100)
+    * `:limit` (integer) - max number of guilds to return (1-200)
+    * `:with_counts` (boolean) - include approximate member and presence counts in response
 
   ## Examples
 

--- a/lib/nostrum/struct/guild.ex
+++ b/lib/nostrum/struct/guild.ex
@@ -63,6 +63,8 @@ defmodule Nostrum.Struct.Guild do
     :preferred_locale,
     :max_video_channel_users,
     :max_stage_video_channel_users,
+    :approximate_member_count,
+    :approximate_presence_count,
     :welcome_screen,
     :nsfw_level,
     :premium_progress_bar_enabled
@@ -226,6 +228,14 @@ defmodule Nostrum.Struct.Guild do
   @typedoc "The maximum amount of users in a stage video channel"
   @type max_stage_video_channel_users :: pos_integer() | nil
 
+  @typedoc since: "NEXTVERSION"
+  @typedoc "The approximate number of members in this guild, included when `:with_counts` is set to `true`"
+  @type approximate_member_count :: pos_integer() | nil
+
+  @typedoc since: "NEXTVERSION"
+  @typedoc "The approximate number of non-offline members in this guild, included when `:with_counts` is set to `true`"
+  @type approximate_presence_count :: pos_integer() | nil
+
   @typedoc "The welcome screen of a Community guild, shown to new members, returned in an Invite's guild object"
   @type welcome_screen :: map() | nil
 
@@ -283,6 +293,8 @@ defmodule Nostrum.Struct.Guild do
           preferred_locale: nil,
           max_video_channel_users: nil,
           max_stage_video_channel_users: nil,
+          approximate_member_count: approximate_member_count,
+          approximate_presence_count: approximate_presence_count,
           welcome_screen: nil,
           nsfw_level: nil,
           premium_progress_bar_enabled: nil,
@@ -335,6 +347,8 @@ defmodule Nostrum.Struct.Guild do
           preferred_locale: nil,
           max_video_channel_users: nil,
           max_stage_video_channel_users: nil,
+          approximate_member_count: approximate_member_count,
+          approximate_presence_count: approximate_presence_count,
           welcome_screen: nil,
           nsfw_level: nil,
           premium_progress_bar_enabled: nil,
@@ -388,6 +402,8 @@ defmodule Nostrum.Struct.Guild do
           max_video_channel_users: nil,
           max_stage_video_channel_users: nil,
           welcome_screen: nil,
+          approximate_member_count: nil,
+          approximate_presence_count: nil,
           nsfw_level: nil,
           premium_progress_bar_enabled: nil,
           safety_alerts_channel_id: nil
@@ -439,6 +455,8 @@ defmodule Nostrum.Struct.Guild do
           preferred_locale: preferred_locale,
           max_video_channel_users: max_video_channel_users,
           max_stage_video_channel_users: max_stage_video_channel_users,
+          approximate_member_count: approximate_member_count,
+          approximate_presence_count: approximate_presence_count,
           welcome_screen: welcome_screen,
           nsfw_level: nsfw_level,
           premium_progress_bar_enabled: premium_progress_bar_enabled,


### PR DESCRIPTION
The `Nostrum.Api.Guild.get/2` and `Nostrum.Api.Self.guilds/2` endpoints are missing support for the `:with_counts` option (#651). This PR adds that option to both functions and the `:approximate_member_count` and `:approximate_presence_count` fields to the guild struct.