### PR TITLE
fix: use struct type in ApiError typespec

### DIFF
--- a/lib/nostrum/error/api_error.ex
+++ b/lib/nostrum/error/api_error.ex
@@ -11,7 +11,7 @@ defmodule Nostrum.Error.ApiError do
     :response
   ]
 
-  @type t :: %{
+  @type t :: %__MODULE__{
           status_code: status_code,
           response: response
         }


### PR DESCRIPTION
The `@type t` for `ApiError` was defined as a plain map (`%{...}`) instead of a struct (`%__MODULE__{...}`). Since `defexception` creates a struct, the typespec should reflect that for accurate Dialyzer analysis.

This is consistent with how all other struct types in the codebase define their `@type t` (e.g., `Nostrum.Struct.Emoji`, `Nostrum.Struct.Guild.Role`).

Closes #725