### PR TITLE
Handle VOICE_CHANNEL_STATUS_UPDATE gateway event

### DIFF
--- a/lib/nostrum/consumer.ex
+++ b/lib/nostrum/consumer.ex
@@ -62,6 +62,7 @@ defmodule Nostrum.Consumer do
     ThreadListSync,
     ThreadMembersUpdate,
     TypingStart,
+    VoiceChannelStatusUpdate,
     VoiceReady,
     VoiceServerUpdate,
     VoiceState
@@ -280,6 +281,8 @@ defmodule Nostrum.Consumer do
   @typedoc since: "0.6.0"
   @type voice_incoming_packet ::
           {:VOICE_INCOMING_PACKET, Nostrum.Voice.rtp_opus(), VoiceWSState.t()}
+  @type voice_channel_status_update ::
+          {:VOICE_CHANNEL_STATUS_UPDATE, VoiceChannelStatusUpdate.t(), WSState.t()}
   @type voice_state_update :: {:VOICE_STATE_UPDATE, VoiceState.t(), WSState.t()}
   @type voice_server_update :: {:VOICE_SERVER_UPDATE, VoiceServerUpdate.t(), WSState.t()}
   @type webhooks_update :: {:WEBHOOKS_UPDATE, map, WSState.t()}
@@ -379,6 +382,7 @@ defmodule Nostrum.Consumer do
           | voice_ready
           | voice_speaking_update
           | voice_incoming_packet
+          | voice_channel_status_update
           | voice_state_update
           | voice_server_update
           | webhooks_update

--- a/lib/nostrum/shard/dispatch.ex
+++ b/lib/nostrum/shard/dispatch.ex
@@ -42,6 +42,7 @@ defmodule Nostrum.Shard.Dispatch do
     ThreadListSync,
     ThreadMembersUpdate,
     TypingStart,
+    VoiceChannelStatusUpdate,
     VoiceReady,
     VoiceServerUpdate,
     VoiceState
@@ -468,6 +469,9 @@ defmodule Nostrum.Shard.Dispatch do
   def handle_event(:MESSAGE_POLL_VOTE_REMOVE = event, p, state) do
     {event, PollVoteChange.to_struct(Map.merge(p, %{type: :remove})), state}
   end
+
+  def handle_event(:VOICE_CHANNEL_STATUS_UPDATE = event, p, state),
+    do: {event, VoiceChannelStatusUpdate.to_struct(p), state}
 
   def handle_event(event, p, state) do
     Logger.warning("UNHANDLED GATEWAY DISPATCH EVENT TYPE: #{event}, #{inspect(p)}")

--- a/lib/nostrum/struct/event/voice_channel_status_update.ex
+++ b/lib/nostrum/struct/event/voice_channel_status_update.ex
@@ -1,0 +1,29 @@
+defmodule Nostrum.Struct.Event.VoiceChannelStatusUpdate do
+  @moduledoc "Sent when a voice channel's status is updated"
+  @moduledoc since: "0.11.0"
+
+  alias Nostrum.Struct.{Channel, Guild}
+
+  defstruct [:id, :guild_id, :status]
+
+  @typedoc "The voice channel ID"
+  @type id :: Channel.id()
+
+  @typedoc "Guild this event is for"
+  @type guild_id :: Guild.id()
+
+  @typedoc "The new channel status, `nil` when cleared"
+  @type status :: String.t() | nil
+
+  @typedoc "Event sent when a voice channel's status is updated"
+  @type t :: %__MODULE__{
+          id: id,
+          guild_id: guild_id,
+          status: status
+        }
+
+  @doc false
+  def to_struct(map) do
+    struct(__MODULE__, map)
+  end
+end


### PR DESCRIPTION
## Summary
Handle the `VOICE_CHANNEL_STATUS_UPDATE` gateway dispatch event instead of logging it as unhandled.

## Motivation
This event is dispatched when a voice channel's status text is set, updated, or cleared. It was reported as unhandled in #688. Other libraries (pycord, serenity, Oceanic) already handle this event.

## Changes
- `lib/nostrum/struct/event/voice_channel_status_update.ex` — new event struct with `id`, `guild_id`, and `status` fields
- `lib/nostrum/shard/dispatch.ex` — add dispatch clause before the catch-all
- `lib/nostrum/consumer.ex` — add type definition and union member

## Event Payload
| Field | Type | Description |
|-------|------|-------------|
| `id` | snowflake | Voice channel ID |
| `guild_id` | snowflake | Guild ID |
| `status` | string \| nil | Channel status text, nil when cleared |

## Testing
- `mix compile` passes
- `mix test` — 212 tests, 0 failures

Ref: #688