### PR TITLE
Handle non-JSON API responses gracefully

### DIFF
--- a/lib/nostrum/api/helpers.ex
+++ b/lib/nostrum/api/helpers.ex
@@ -6,7 +6,17 @@ defmodule Nostrum.Api.Helpers do
   defguard has_files(args) when is_map_key(args, :files) or is_map_key(args, :file)
 
   def handle_request_with_decode(response)
-  def handle_request_with_decode({:ok, body}), do: {:ok, Jason.decode!(body, keys: :atoms)}
+
+  def handle_request_with_decode({:ok, body}) do
+    case Jason.decode(body, keys: :atoms) do
+      {:ok, parsed} ->
+        {:ok, parsed}
+
+      {:error, _} ->
+        {:error, %Nostrum.Error.ApiError{status_code: nil, response: body}}
+    end
+  end
+
   def handle_request_with_decode({:error, _} = error), do: error
 
   def handle_request_with_decode(response, type)
@@ -15,12 +25,13 @@ defmodule Nostrum.Api.Helpers do
   def handle_request_with_decode({:error, _} = error, _type), do: error
 
   def handle_request_with_decode({:ok, body}, type) do
-    convert =
-      body
-      |> Jason.decode!(keys: :atoms)
-      |> Util.cast(type)
+    case Jason.decode(body, keys: :atoms) do
+      {:ok, parsed} ->
+        {:ok, Util.cast(parsed, type)}
 
-    {:ok, convert}
+      {:error, _} ->
+        {:error, %Nostrum.Error.ApiError{status_code: nil, response: body}}
+    end
   end
 
   @spec maybe_add_reason(String.t() | nil, list()) :: list()

--- a/lib/nostrum/util.ex
+++ b/lib/nostrum/util.ex
@@ -91,13 +91,17 @@ defmodule Nostrum.Util do
         raise(Nostrum.Error.ApiError, status_code: code, message: message)
 
       {:ok, body} ->
-        body = Jason.decode!(body)
+        case Jason.decode(body) do
+          {:ok, decoded} ->
+            "wss://" <> url = decoded["url"]
+            shards = if decoded["shards"], do: decoded["shards"], else: 1
 
-        "wss://" <> url = body["url"]
-        shards = if body["shards"], do: body["shards"], else: 1
+            :persistent_term.put(@gateway_url_key, {url, shards})
+            {url, shards}
 
-        :persistent_term.put(@gateway_url_key, {url, shards})
-        {url, shards}
+          {:error, _} ->
+            raise("Received non-JSON response from Discord gateway, Discord may be down")
+        end
     end
   end
 


### PR DESCRIPTION
## Summary
Replace `Jason.decode!` with `Jason.decode` in API response handling, so that non-JSON responses produce clear errors instead of crashing with a confusing `Jason.DecodeError`.

## Motivation
When Discord is down or a proxy returns an HTML error page (e.g. 502 Bad Gateway), the ratelimiter may forward a non-JSON body that causes `Jason.decode!` to crash with a misleading error like:

```
** (Jason.DecodeError) unexpected byte at position 0: 0x3C ("<")
```

This makes it look like a protocol-level bug when the actual issue is just that Discord is down. As discussed in #417, using `Jason.decode` (non-bang) and handling the error case provides a much clearer signal.

## Changes
- `lib/nostrum/api/helpers.ex` — `handle_request_with_decode/1` and `handle_request_with_decode/2` now use `Jason.decode` and return `{:error, %ApiError{}}` on decode failure
- `lib/nostrum/util.ex` — `get_new_gateway_url/0` now uses `Jason.decode` and raises a descriptive message on failure

## Testing
- `mix compile --warnings-as-errors` passes
- `mix test` — 212 tests, 0 failures

Closes #417