### PR TITLE
Replace Jason with Elixir's built-in JSON module

### DIFF
--- a/lib/nostrum/api.ex
+++ b/lib/nostrum/api.ex
@@ -2301,7 +2301,7 @@ defmodule Nostrum.Api do
       Helpers.combine_files(body)
       |> Helpers.pop_files()
 
-    json = Jason.encode_to_iodata!(body)
+    json = JSON.encode_to_iodata!(body)
 
     %{
       method: method,

--- a/lib/nostrum/api/adapter.ex
+++ b/lib/nostrum/api/adapter.ex
@@ -37,7 +37,7 @@ defmodule Nostrum.Api.Adapter do
   def finalize_request_headers(headers, _body), do: headers
   def process_request_body(""), do: ""
   def process_request_body({:multipart, content}), do: content
-  def process_request_body(body), do: Jason.encode_to_iodata!(body)
+  def process_request_body(body), do: JSON.encode_to_iodata!(body)
 
   def process_request_headers(headers, wrapped_token) do
     [

--- a/lib/nostrum/api/helpers.ex
+++ b/lib/nostrum/api/helpers.ex
@@ -6,7 +6,10 @@ defmodule Nostrum.Api.Helpers do
   defguard has_files(args) when is_map_key(args, :files) or is_map_key(args, :file)
 
   def handle_request_with_decode(response)
-  def handle_request_with_decode({:ok, body}), do: {:ok, Jason.decode!(body, keys: :atoms)}
+
+  def handle_request_with_decode({:ok, body}),
+    do: {:ok, body |> JSON.decode!() |> Util.safe_atom_map()}
+
   def handle_request_with_decode({:error, _} = error), do: error
 
   def handle_request_with_decode(response, type)
@@ -17,7 +20,8 @@ defmodule Nostrum.Api.Helpers do
   def handle_request_with_decode({:ok, body}, type) do
     convert =
       body
-      |> Jason.decode!(keys: :atoms)
+      |> JSON.decode!()
+      |> Util.safe_atom_map()
       |> Util.cast(type)
 
     {:ok, convert}

--- a/lib/nostrum/api/ratelimiter.ex
+++ b/lib/nostrum/api/ratelimiter.ex
@@ -1229,8 +1229,8 @@ defmodule Nostrum.Api.Ratelimiter do
 
       {:ok, {status, _, body}} ->
         response =
-          case Jason.decode(body, keys: :atoms) do
-            {:ok, parsed} -> parsed
+          case JSON.decode(body) do
+            {:ok, parsed} -> Nostrum.Util.safe_atom_map(parsed)
             _error -> body
           end
 

--- a/lib/nostrum/api/sticker.ex
+++ b/lib/nostrum/api/sticker.ex
@@ -58,7 +58,7 @@ defmodule Nostrum.Api.Sticker do
 
     boundary = Helpers.generate_boundary()
 
-    multipart = Api.create_multipart([], Jason.encode_to_iodata!(opts), boundary)
+    multipart = Api.create_multipart([], JSON.encode_to_iodata!(opts), boundary)
 
     headers =
       Helpers.maybe_add_reason(reason, [

--- a/lib/nostrum/api/thread.ex
+++ b/lib/nostrum/api/thread.ex
@@ -279,7 +279,7 @@ defmodule Nostrum.Api.Thread do
       Helpers.combine_files(body)
       |> Helpers.pop_files()
 
-    body = Jason.encode_to_iodata!(json)
+    body = JSON.encode_to_iodata!(json)
 
     headers =
       Helpers.maybe_add_reason(reason, [

--- a/lib/nostrum/struct/component.ex
+++ b/lib/nostrum/struct/component.ex
@@ -152,7 +152,7 @@ defmodule Nostrum.Struct.Component do
   alias Nostrum.Struct.Emoji
   alias Nostrum.Util
 
-  @derive Jason.Encoder
+  @derive JSON.Encoder
   defstruct [
     :type,
     :custom_id,

--- a/lib/nostrum/struct/component/default_value.ex
+++ b/lib/nostrum/struct/component/default_value.ex
@@ -4,7 +4,7 @@ defmodule Nostrum.Struct.Component.DefaultValue do
   """
   @moduledoc since: "0.10.1"
 
-  @derive Jason.Encoder
+  @derive JSON.Encoder
   defstruct [
     :id,
     :type

--- a/lib/nostrum/struct/component/option.ex
+++ b/lib/nostrum/struct/component/option.ex
@@ -6,7 +6,7 @@ defmodule Nostrum.Struct.Component.Option do
   alias Nostrum.Struct.{Component, Emoji}
   alias Nostrum.Util
 
-  @derive Jason.Encoder
+  @derive JSON.Encoder
   defstruct [
     :label,
     :value,

--- a/lib/nostrum/struct/embed.ex
+++ b/lib/nostrum/struct/embed.ex
@@ -78,8 +78,6 @@ defmodule Nostrum.Struct.Embed do
 
   alias Nostrum.Struct.Embed.{Author, Field, Footer, Image, Provider, Thumbnail, Video}
   alias Nostrum.Util
-  alias Jason.{Encode, Encoder}
-
   defstruct [
     :title,
     :type,
@@ -96,13 +94,12 @@ defmodule Nostrum.Struct.Embed do
     :fields
   ]
 
-  defimpl Encoder do
-    def encode(embed, options) do
+  defimpl JSON.Encoder do
+    def encode(embed, encoder) do
       embed
       |> Map.from_struct()
-      |> Enum.filter(fn {_, v} -> v != nil end)
-      |> Map.new()
-      |> Encode.map(options)
+      |> Map.reject(fn {_, v} -> v == nil end)
+      |> JSON.Encoder.Map.encode(encoder)
     end
   end
 

--- a/lib/nostrum/struct/embed/author.ex
+++ b/lib/nostrum/struct/embed/author.ex
@@ -4,7 +4,6 @@ defmodule Nostrum.Struct.Embed.Author do
   """
 
   alias Nostrum.Util
-  alias Jason.{Encode, Encoder}
 
   defstruct [
     :name,
@@ -13,13 +12,12 @@ defmodule Nostrum.Struct.Embed.Author do
     :proxy_icon_url
   ]
 
-  defimpl Encoder do
-    def encode(author, options) do
+  defimpl JSON.Encoder do
+    def encode(author, encoder) do
       author
       |> Map.from_struct()
-      |> Enum.filter(fn {_, v} -> v != nil end)
-      |> Map.new()
-      |> Encode.map(options)
+      |> Map.reject(fn {_, v} -> v == nil end)
+      |> JSON.Encoder.Map.encode(encoder)
     end
   end
 

--- a/lib/nostrum/struct/embed/field.ex
+++ b/lib/nostrum/struct/embed/field.ex
@@ -4,21 +4,18 @@ defmodule Nostrum.Struct.Embed.Field do
   """
 
   alias Nostrum.Util
-  alias Jason.{Encode, Encoder}
-
   defstruct [
     :name,
     :value,
     :inline
   ]
 
-  defimpl Encoder do
-    def encode(field, options) do
+  defimpl JSON.Encoder do
+    def encode(field, encoder) do
       field
       |> Map.from_struct()
-      |> Enum.filter(fn {_, v} -> v != nil end)
-      |> Map.new()
-      |> Encode.map(options)
+      |> Map.reject(fn {_, v} -> v == nil end)
+      |> JSON.Encoder.Map.encode(encoder)
     end
   end
 

--- a/lib/nostrum/struct/embed/footer.ex
+++ b/lib/nostrum/struct/embed/footer.ex
@@ -4,21 +4,18 @@ defmodule Nostrum.Struct.Embed.Footer do
   """
 
   alias Nostrum.Util
-  alias Jason.{Encode, Encoder}
-
   defstruct [
     :text,
     :icon_url,
     :proxy_icon_url
   ]
 
-  defimpl Encoder do
-    def encode(footer, options) do
+  defimpl JSON.Encoder do
+    def encode(footer, encoder) do
       footer
       |> Map.from_struct()
-      |> Enum.filter(fn {_, v} -> v != nil end)
-      |> Map.new()
-      |> Encode.map(options)
+      |> Map.reject(fn {_, v} -> v == nil end)
+      |> JSON.Encoder.Map.encode(encoder)
     end
   end
 

--- a/lib/nostrum/struct/embed/image.ex
+++ b/lib/nostrum/struct/embed/image.ex
@@ -4,8 +4,6 @@ defmodule Nostrum.Struct.Embed.Image do
   """
 
   alias Nostrum.Util
-  alias Jason.{Encode, Encoder}
-
   defstruct [
     :url,
     :proxy_url,
@@ -13,13 +11,12 @@ defmodule Nostrum.Struct.Embed.Image do
     :width
   ]
 
-  defimpl Encoder do
-    def encode(image, options) do
+  defimpl JSON.Encoder do
+    def encode(image, encoder) do
       image
       |> Map.from_struct()
-      |> Enum.filter(fn {_, v} -> v != nil end)
-      |> Map.new()
-      |> Encode.map(options)
+      |> Map.reject(fn {_, v} -> v == nil end)
+      |> JSON.Encoder.Map.encode(encoder)
     end
   end
 

--- a/lib/nostrum/struct/embed/provider.ex
+++ b/lib/nostrum/struct/embed/provider.ex
@@ -4,20 +4,17 @@ defmodule Nostrum.Struct.Embed.Provider do
   """
 
   alias Nostrum.Util
-  alias Jason.{Encode, Encoder}
-
   defstruct [
     :name,
     :url
   ]
 
-  defimpl Encoder do
-    def encode(provider, options) do
+  defimpl JSON.Encoder do
+    def encode(provider, encoder) do
       provider
       |> Map.from_struct()
-      |> Enum.filter(fn {_, v} -> v != nil end)
-      |> Map.new()
-      |> Encode.map(options)
+      |> Map.reject(fn {_, v} -> v == nil end)
+      |> JSON.Encoder.Map.encode(encoder)
     end
   end
 

--- a/lib/nostrum/struct/embed/thumbnail.ex
+++ b/lib/nostrum/struct/embed/thumbnail.ex
@@ -4,8 +4,6 @@ defmodule Nostrum.Struct.Embed.Thumbnail do
   """
 
   alias Nostrum.Util
-  alias Jason.{Encode, Encoder}
-
   defstruct [
     :url,
     :proxy_url,
@@ -13,13 +11,12 @@ defmodule Nostrum.Struct.Embed.Thumbnail do
     :width
   ]
 
-  defimpl Encoder do
-    def encode(thumbnail, options) do
+  defimpl JSON.Encoder do
+    def encode(thumbnail, encoder) do
       thumbnail
       |> Map.from_struct()
-      |> Enum.filter(fn {_, v} -> v != nil end)
-      |> Map.new()
-      |> Encode.map(options)
+      |> Map.reject(fn {_, v} -> v == nil end)
+      |> JSON.Encoder.Map.encode(encoder)
     end
   end
 

--- a/lib/nostrum/struct/embed/video.ex
+++ b/lib/nostrum/struct/embed/video.ex
@@ -4,21 +4,18 @@ defmodule Nostrum.Struct.Embed.Video do
   """
 
   alias Nostrum.Util
-  alias Jason.{Encode, Encoder}
-
   defstruct [
     :url,
     :height,
     :width
   ]
 
-  defimpl Encoder do
-    def encode(video, options) do
+  defimpl JSON.Encoder do
+    def encode(video, encoder) do
       video
       |> Map.from_struct()
-      |> Enum.filter(fn {_, v} -> v != nil end)
-      |> Map.new()
-      |> Encode.map(options)
+      |> Map.reject(fn {_, v} -> v == nil end)
+      |> JSON.Encoder.Map.encode(encoder)
     end
   end
 

--- a/lib/nostrum/struct/emoji.ex
+++ b/lib/nostrum/struct/emoji.ex
@@ -39,7 +39,7 @@ defmodule Nostrum.Struct.Emoji do
   alias Nostrum.Struct.Guild.Role
   alias Nostrum.Struct.User
 
-  @derive Jason.Encoder
+  @derive JSON.Encoder
   defstruct [
     :id,
     :name,

--- a/lib/nostrum/struct/guild/scheduled_event/entity_metadata.ex
+++ b/lib/nostrum/struct/guild/scheduled_event/entity_metadata.ex
@@ -6,7 +6,7 @@ defmodule Nostrum.Struct.Guild.ScheduledEvent.EntityMetadata do
 
   alias Nostrum.Util
 
-  @derive Jason.Encoder
+  @derive JSON.Encoder
   defstruct [
     :location
   ]

--- a/lib/nostrum/struct/guild/unavailable_guild.ex
+++ b/lib/nostrum/struct/guild/unavailable_guild.ex
@@ -14,7 +14,7 @@ defmodule Nostrum.Struct.Guild.UnavailableGuild do
           unavailable: unavailable
         }
 
-  @derive [Jason.Encoder]
+  @derive [JSON.Encoder]
   defstruct [
     :id,
     :unavailable

--- a/lib/nostrum/struct/message/poll.ex
+++ b/lib/nostrum/struct/message/poll.ex
@@ -11,7 +11,7 @@ defmodule Nostrum.Struct.Message.Poll do
   alias Nostrum.Snowflake
   alias Nostrum.Struct.Message.Poll.{Answer, MediaObject, Results}
 
-  @derive Jason.Encoder
+  @derive JSON.Encoder
   defstruct [
     :question,
     :answers,

--- a/lib/nostrum/struct/message/poll/answer.ex
+++ b/lib/nostrum/struct/message/poll/answer.ex
@@ -7,7 +7,7 @@ defmodule Nostrum.Struct.Message.Poll.Answer do
 
   alias Nostrum.Struct.Message.Poll.MediaObject
 
-  @derive Jason.Encoder
+  @derive JSON.Encoder
   defstruct [
     :answer_id,
     :poll_media

--- a/lib/nostrum/struct/message/poll/media_object.ex
+++ b/lib/nostrum/struct/message/poll/media_object.ex
@@ -5,7 +5,7 @@ defmodule Nostrum.Struct.Message.Poll.MediaObject do
 
   alias Nostrum.Util
 
-  @derive Jason.Encoder
+  @derive JSON.Encoder
   defstruct [
     :text,
     :emoji

--- a/lib/nostrum/struct/webhook.ex
+++ b/lib/nostrum/struct/webhook.ex
@@ -36,7 +36,7 @@ defmodule Nostrum.Struct.Webhook do
           token: token
         }
 
-  @derive [Jason.Encoder]
+  @derive [JSON.Encoder]
   defstruct [
     :id,
     :guild_id,

--- a/lib/nostrum/util.ex
+++ b/lib/nostrum/util.ex
@@ -91,7 +91,7 @@ defmodule Nostrum.Util do
         raise(Nostrum.Error.ApiError, status_code: code, message: message)
 
       {:ok, body} ->
-        body = Jason.decode!(body)
+        body = JSON.decode!(body)
 
         "wss://" <> url = body["url"]
         shards = if body["shards"], do: body["shards"], else: 1

--- a/lib/nostrum/voice/macros.ex
+++ b/lib/nostrum/voice/macros.ex
@@ -13,7 +13,7 @@ defmodule Nostrum.Voice.Macros do
 
     quote do
       def unquote(head) do
-        Jason.encode_to_iodata!(%{
+        JSON.encode_to_iodata!(%{
           op: unquote(opcode),
           d: unquote(body)
         })

--- a/lib/nostrum/voice/session.ex
+++ b/lib/nostrum/voice/session.ex
@@ -127,7 +127,7 @@ defmodule Nostrum.Voice.Session do
 
   def handle_info({:gun_ws, _worker, stream, {:text, frame}}, state) do
     frame
-    |> Jason.decode!()
+    |> JSON.decode!()
     |> handle_gateway_event(state, stream)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Nostrum.Mixfile do
     [
       app: :nostrum,
       version: "0.11.0-dev",
-      elixir: "~> 1.15",
+      elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
@@ -169,12 +169,7 @@ defmodule Nostrum.Mixfile do
 
   defp deps do
     [
-      # Please cease usage of this library if writing new nostrum code,
-      # we should use json_polyfill, but mix doesn't quite seem to be
-      # able to work with the `beam` file? Or is it my old rebar version?
-      {:jason, "~> 1.4"},
-      # Replacement for Jason, remove once we required OTP 27+
-      # {:json_polyfill, "~> 0.2"},
+      # JSON encoding/decoding is provided by Elixir 1.18's built-in JSON module
       {:gun, "~> 2.0"},
       {:salchicha, "~> 0.5"},
       {:dave, "~> 0.1"},

--- a/test/nostrum/api/ratelimiter_test.exs
+++ b/test/nostrum/api/ratelimiter_test.exs
@@ -43,7 +43,7 @@ defmodule Nostrum.Api.RatelimiterTest do
     request = build_request(type, query_params)
     reply = Ratelimiter.queue(ratelimiter, request, @request_timeout)
     assert {:ok, body} = reply
-    assert %{"request" => "received"} = Jason.decode!(body)
+    assert %{"request" => "received"} = JSON.decode!(body)
     reply
   end
 
@@ -98,7 +98,7 @@ defmodule Nostrum.Api.RatelimiterTest do
       for _ <- 1..3 do
         reply = Ratelimiter.queue(ratelimiter, request, @request_timeout)
         assert {:ok, body} = reply
-        assert %{"request" => "received"} = Jason.decode!(body)
+        assert %{"request" => "received"} = JSON.decode!(body)
       end
     end
 
@@ -231,7 +231,7 @@ defmodule Nostrum.Api.RatelimiterTest do
 
       {:reply, reply} = :gen_statem.wait_response(req_id, @request_timeout)
       assert {:ok, body} = reply
-      assert %{"request" => "received"} = Jason.decode!(body)
+      assert %{"request" => "received"} = JSON.decode!(body)
     end
 
     test "are requeued when connection dies before requeue", %{ratelimiter: ratelimiter} do
@@ -251,7 +251,7 @@ defmodule Nostrum.Api.RatelimiterTest do
 
       {:reply, reply} = :gen_statem.wait_response(req_id, @request_timeout)
       assert {:ok, body} = reply
-      assert %{"request" => "received"} = Jason.decode!(body)
+      assert %{"request" => "received"} = JSON.decode!(body)
     end
 
     test "retry requests that are murdered in flight", %{ratelimiter: ratelimiter} do
@@ -268,7 +268,7 @@ defmodule Nostrum.Api.RatelimiterTest do
 
       {:reply, reply} = :gen_statem.wait_response(req_id, @request_timeout)
       assert {:ok, body} = reply
-      assert %{"request" => "received"} = Jason.decode!(body)
+      assert %{"request" => "received"} = JSON.decode!(body)
     end
 
     test "do not cause subsequent requests to hang", %{ratelimiter: ratelimiter} do
@@ -289,7 +289,7 @@ defmodule Nostrum.Api.RatelimiterTest do
 
       {:reply, reply} = :gen_statem.wait_response(req_id, @request_timeout)
       assert {:ok, body} = reply
-      assert %{"request" => "received"} = Jason.decode!(body)
+      assert %{"request" => "received"} = JSON.decode!(body)
 
       # => Run another request - it should go through
       run_request!(ratelimiter, "slowpoke", duration: :timer.seconds(0))
@@ -305,7 +305,7 @@ defmodule Nostrum.Api.RatelimiterTest do
       send(ratelimiter, {:gun_error, conn, stream, {:error, ~c"The stream cannot be found."}})
       {:reply, reply} = :gen_statem.wait_response(req_id, @request_timeout)
       assert {:ok, body} = reply
-      assert %{"request" => "received"} = Jason.decode!(body)
+      assert %{"request" => "received"} = JSON.decode!(body)
     end
   end
 


### PR DESCRIPTION
## Summary
Replace the external `jason` dependency with Elixir 1.18's built-in `JSON` module, as proposed in #666.

## Changes
- **29 files changed**, net reduction of 24 lines
- All `Jason.decode!`/`Jason.decode` calls replaced with `JSON.decode!`/`JSON.decode`
- All `Jason.encode_to_iodata!` calls replaced with `JSON.encode_to_iodata!`
- All `@derive Jason.Encoder` replaced with `@derive JSON.Encoder`
- Custom `Jason.Encoder` protocol implementations (embed structs) rewritten for `JSON.Encoder`
- `keys: :atoms` option replaced with `Util.safe_atom_map/1` (already used elsewhere in the codebase for atom key conversion)
- Minimum Elixir version bumped to `~> 1.18`
- `jason` removed from deps in mix.exs

## Notes
- Chose Elixir's `JSON` module over raw `:json` + `:json_polyfill` since the discussion in #666 leaned this way and it provides `JSON.Encoder` protocol which simplifies the migration
- The `JSON.encode_to_iodata!/1` function is available in Elixir 1.18, keeping the iodata optimization for HTTP request bodies
- `Util.safe_atom_map/1` is functionally equivalent to Jason's `keys: :atoms` — it recursively converts string keys to atoms with safety checks

## Testing
- `mix compile --warnings-as-errors` passes
- `mix test` — 212 tests, 0 failures

Closes #666