### PR TITLE
fix(ratelimiter): honor global 429 semantics from body / Retry-After

### DIFF
--- a/lib/nostrum/api/ratelimiter.ex
+++ b/lib/nostrum/api/ratelimiter.ex
@@ -825,8 +825,16 @@ defmodule Nostrum.Api.Ratelimiter do
          ]}
 
       kind == :nofin ->
+        # For 429s we defer `parse_limits` until the body has arrived, since
+        # the authoritative ratelimit information (global flag, retry_after)
+        # is carried in the JSON body and may not be present in the headers.
         inflight_with_this = Map.put(inflight, stream, {status, headers, ""})
-        {:keep_state, %{data | inflight: inflight_with_this}, parse_limits}
+
+        if status == 429 do
+          {:keep_state, %{data | inflight: inflight_with_this}}
+        else
+          {:keep_state, %{data | inflight: inflight_with_this}, parse_limits}
+        end
     end
   end
 
@@ -848,7 +856,7 @@ defmodule Nostrum.Api.Ratelimiter do
         {:gun_data, _conn, stream, :fin, body},
         %{inflight: inflight, running: running} = data
       ) do
-    {{_bucket, request, from}, running_without_this} = Map.pop(running, stream)
+    {{bucket, request, from}, running_without_this} = Map.pop(running, stream)
     {{status, headers, buffer}, inflight_without_this} = Map.pop(inflight, stream)
     full_buffer = <<buffer::binary, body::binary>>
     unparsed = parse_response(status, headers, full_buffer)
@@ -859,11 +867,18 @@ defmodule Nostrum.Api.Ratelimiter do
       429 ->
         # Not great - this should ideally be a global or user ratelimit, both
         # things which we don't receive any anticipation about from the API.
-        # Give the request a second chance. Note that dealing with entering the
-        # global or user ratelimit was already performed by `parse_limits` in
-        # an earlier step.
+        # Parse ratelimit information from the full response (headers + body)
+        # now: this may transition us into the global limit state based on the
+        # 429 body's `global` and `retry_after` fields, which is why we
+        # deferred `parse_limits` for 429 responses with a body until this
+        # point. Event ordering guarantees `parse_limits` is handled before
+        # the `requeue`, so the requeue will be postponed by the resulting
+        # global_limit state as needed.
+        limits = parse_headers(unparsed)
+
         {:keep_state, new_data,
          [
+           {:next_event, :internal, {:parse_limits, limits, bucket}},
            {:next_event, :internal, {:requeue, {request, from}, :hit_429}}
          ]}
 
@@ -1152,7 +1167,7 @@ defmodule Nostrum.Api.Ratelimiter do
   # defp parse_headers({:error, _reason} = result), do: result
 
   # credo:disable-for-next-line
-  defp parse_headers({:ok, {_status, headers, _body}}) do
+  defp parse_headers({:ok, {status, headers, body}}) do
     limit_scope = header_value(headers, "x-ratelimit-scope")
     remaining = header_value(headers, "x-ratelimit-remaining")
     remaining = if remaining, do: String.to_integer(remaining)
@@ -1163,7 +1178,10 @@ defmodule Nostrum.Api.Ratelimiter do
 
     cond do
       is_nil(remaining) and is_nil(reset_after) ->
-        :congratulations_you_killed_upstream
+        # Perhaps a 429 with only the standard Retry-After header or a JSON
+        # body telling us about the ratelimit. Check those before declaring
+        # the bucket dead.
+        parse_429_fallback(status, headers, body)
 
       limit_scope == "user" and remaining == 0 ->
         # Per bot or user limit.
@@ -1178,6 +1196,48 @@ defmodule Nostrum.Api.Ratelimiter do
         {:bucket_limit, {remaining, reset_after}}
     end
   end
+
+  # Fallback parsing for 429 responses that didn't match the header-based
+  # ratelimit patterns. Discord's authoritative source for 429 information is
+  # the JSON body, which carries `global` and `retry_after`.  When the body is
+  # unavailable (or doesn't parse), we fall back to the standard `Retry-After`
+  # header.
+  @spec parse_429_fallback(non_neg_integer(), [{String.t(), String.t()}], String.t()) ::
+          {:global_limit | :user_limit, non_neg_integer()}
+          | :congratulations_you_killed_upstream
+  defp parse_429_fallback(429, headers, body) do
+    case decode_429_body(body) do
+      {:ok, %{"global" => true, "retry_after" => retry_after}} ->
+        {:global_limit, trunc(retry_after * 1000)}
+
+      {:ok, %{"retry_after" => retry_after}} ->
+        {:user_limit, trunc(retry_after * 1000)}
+
+      _ ->
+        case header_value(headers, "retry-after") do
+          nil -> :congratulations_you_killed_upstream
+          retry_after -> {:user_limit, retry_after_to_millis(retry_after)}
+        end
+    end
+  end
+
+  defp parse_429_fallback(_status, _headers, _body), do: :congratulations_you_killed_upstream
+
+  # Discord sends Retry-After as integer seconds ("65"); be defensive about
+  # fractional values ("1.5") in case a proxy rewrites the header.
+  @spec retry_after_to_millis(String.t()) :: non_neg_integer()
+  defp retry_after_to_millis(value) do
+    case Float.parse(value) do
+      {float_value, ""} -> trunc(float_value * 1000)
+      :error -> 0
+    end
+  end
+
+  defp decode_429_body(body) when is_binary(body) and body != "" do
+    Jason.decode(body)
+  end
+
+  defp decode_429_body(_body), do: :error
 
   # Use :timer.time() when / if it is exported
   @spec requeue_after_for_reason(:hit_429 | :abnormal_close) :: pos_integer()

--- a/test/nostrum/api/ratelimiter_test.exs
+++ b/test/nostrum/api/ratelimiter_test.exs
@@ -90,6 +90,30 @@ defmodule Nostrum.Api.RatelimiterTest do
     end
   end
 
+  # Spin until the ratelimiter enters the given state. Used to observe
+  # transitions into `:global_limit` that happen as a side effect of a 429
+  # response. Returns {:ok, state_name} on success, {:error, :timeout}
+  # otherwise.
+  defp spin_until_state(ratelimiter, target_state, timeout \\ @request_timeout) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    do_spin_until_state(ratelimiter, target_state, deadline)
+  end
+
+  defp do_spin_until_state(ratelimiter, target_state, deadline) do
+    if System.monotonic_time(:millisecond) > deadline do
+      {:error, :timeout}
+    else
+      case :sys.get_state(ratelimiter) do
+        {state, _data} when state == target_state ->
+          {:ok, state}
+
+        _other ->
+          Process.sleep(10)
+          do_spin_until_state(ratelimiter, target_state, deadline)
+      end
+    end
+  end
+
   describe "basic requests" do
     test "work", %{ratelimiter: ratelimiter} do
       request = build_request("endpoint")
@@ -201,6 +225,46 @@ defmodule Nostrum.Api.RatelimiterTest do
 
       refute_receive _, 200
       assert_receive {:ok, _body}, 200
+    end
+  end
+
+  # Issue #709: Discord's global 429 on /gateway/bot carries the ratelimit
+  # information only in the JSON body (`global` + `retry_after`) and may lack
+  # the x-ratelimit-* headers entirely. The ratelimiter must respect this and
+  # enter the global limit state, not loop the retry with no known ratelimit
+  # information.
+  describe "429 with ratelimit information only in the response body" do
+    test "global: true enters global_limit state", %{ratelimiter: ratelimiter} do
+      request = build_request("global_429_body_only")
+      _req_id = :gen_statem.send_request(ratelimiter, {:queue, request})
+
+      # The ratelimiter must have transitioned into global_limit state from
+      # the 429 body alone. Spin until we observe it (with a timeout).
+      assert {:ok, :global_limit} = spin_until_state(ratelimiter, :global_limit)
+
+      # Note: we don't wait for the request to complete; the test endpoint
+      # always returns 429, so the ratelimiter would keep re-entering the
+      # global_limit state. Observing the entry alone proves the fix.
+    end
+
+    test "global: false enters user_limit state (treated as global_limit)", %{
+      ratelimiter: ratelimiter
+    } do
+      request = build_request("user_429_body_only")
+      _req_id = :gen_statem.send_request(ratelimiter, {:queue, request})
+
+      # Both user_limit and global_limit transition the state machine into
+      # the :global_limit state in this implementation.
+      assert {:ok, :global_limit} = spin_until_state(ratelimiter, :global_limit)
+    end
+  end
+
+  describe "429 with only a Retry-After header" do
+    test "honors the header value as a user limit", %{ratelimiter: ratelimiter} do
+      request = build_request("user_429_retry_after_header")
+      _req_id = :gen_statem.send_request(ratelimiter, {:queue, request})
+
+      assert {:ok, :global_limit} = spin_until_state(ratelimiter, :global_limit)
     end
   end
 

--- a/test/nostrum/api_server.ex
+++ b/test/nostrum/api_server.ex
@@ -86,6 +86,51 @@ defmodule :nostrum_test_api_server do
       )
   end
 
+  # Simulates Discord's global 429 as observed on /gateway/bot in issue #709:
+  # none of the x-ratelimit-* headers are present, the only ratelimit
+  # information is in the JSON body. The ratelimiter must enter the global
+  # limit state from the body alone.
+  def global_429_body_only(session, _env, _input) do
+    :ok =
+      :mod_esi.deliver(
+        session,
+        ~c"""
+        status: 429 Too Many Requests\r
+        Content-Type: application/json\r
+        \r
+        {"message": "You are being rate limited.", "retry_after": 0.2, "global": true}
+        """
+      )
+  end
+
+  # Simulates a 429 where the only ratelimit information available is the
+  # standard Retry-After header - no x-ratelimit-* headers and no body.
+  def user_429_retry_after_header(session, _env, _input) do
+    :ok =
+      :mod_esi.deliver(
+        session,
+        ~c"""
+        status: 429 Too Many Requests\r
+        retry-after: 1\r
+        \r
+        """
+      )
+  end
+
+  # Simulates a non-global 429 with information in the JSON body only.
+  def user_429_body_only(session, _env, _input) do
+    :ok =
+      :mod_esi.deliver(
+        session,
+        ~c"""
+        status: 429 Too Many Requests\r
+        Content-Type: application/json\r
+        \r
+        {"message": "You are being rate limited.", "retry_after": 0.2, "global": false}
+        """
+      )
+  end
+
   def user_limit(session, _env, _input) do
     :ok =
       :mod_esi.deliver(


### PR DESCRIPTION
## Summary

Fixes the infinite retry loop reported in Kraigie/nostrum#709 by teaching the ratelimiter to respect Discord's authoritative 429 semantics — the JSON body (`global`, `retry_after`) and the standard `Retry-After` header — when the `x-ratelimit-*` headers are missing or unrecognized.

Previously, a header-stripped global 429 (the shape Discord actually sends on `/gateway/bot`) fell into `:congratulations_you_killed_upstream`, scheduling a 1s bucket reset that was then overwritten by the 10s `:hit_429` requeue. The two share the same `gen_statem` timer key on the bucket, so the loop was unbreakable and shards blocked on `/gateway/bot` never reconnected.

## Root cause

`Nostrum.Api.Ratelimiter.parse_headers/1` only looked at `x-ratelimit-scope`, `x-ratelimit-remaining`, and `x-ratelimit-reset-after`. When none of these were present:

1. `parse_limits` classified the result as `:congratulations_you_killed_upstream` and scheduled the bucket's timeout for 1s.
2. The `gun_response :fin` handler simultaneously scheduled an internal `{:requeue, ..., :hit_429}` for ~10s later — on the **same** `{timeout, bucket}` timer key, replacing the 1s reset.
3. The requeue fired every ~10s with the warning *"Retrying request for reason hit_429 with no known ratelimit information to \"/gateway/bot\" queued by ..."* — forever.

Simply bumping the 1s timer (e.g., to 60s) does not help; the `:hit_429` requeue still overwrites it on the same key. This was tried on the unmerged branch `longer-wait-for-global-limit`.

## Fix

The change is contained to `lib/nostrum/api/ratelimiter.ex`:

1. **`parse_headers/1` header-stripped branch** — instead of returning `:congratulations_you_killed_upstream` immediately, calls `parse_429_fallback/3` which consults, in priority order:
   - The 429 JSON body's `global` flag and `retry_after` field → `{:global_limit, ms}` or `{:user_limit, ms}`.
   - The standard `Retry-After` HTTP header → `{:user_limit, ms}`.
   - Otherwise → `:congratulations_you_killed_upstream` (preserving the existing degraded behavior for true upstream errors).

2. **Defer `parse_limits` for `:nofin` 429s** — for 429 responses *with* a body, ratelimit information can't be fully evaluated from headers alone (the body's `global` flag may force `global_limit`). The internal `parse_limits` event is now scheduled from the `gun_data :fin` handler instead, once the body has been buffered.

3. **`gun_data :fin` 429 handler** — now emits `{:parse_limits, limits, bucket}` **before** the `{:requeue, ..., :hit_429}` event. `gen_statem` event ordering means the resulting state transition (typically into `:global_limit`) is already in effect when the requeue is processed, and the `:global_limit` state postpones the requeue until the global timeout elapses — exactly what we want.

The existing `:global_limit` state then handles everything correctly: postpones queued events, schedules a `:state_timeout` for `retry_after` ms, and returns to `:connected` when the global limit expires.

Honoring `global: false` body semantics with a `:user_limit` classification is intentional: the existing handler treats `:user_limit` and `:global_limit` equivalently (both transition the gen_statem into `:global_limit` state for `retry_after` ms), so per-user 429s also stall the limiter correctly rather than hammering a 10s loop.

## Tests

The pre-existing global-limit test only exercised the **header-well-formed** path (`api_server.ex` `global_limit/3` returns full `x-ratelimit-scope: global` / `remaining: 0` / `reset-after: 0.2`), which already worked. New test coverage targets the regression case directly:

- **`api_server.ex`**:
  - `global_429_body_only/3` — real Discord global 429 shape: 429 + body `{"message": "...", "retry_after": 0.2, "global": true}`, **no** `x-ratelimit-*` headers.
  - `user_429_body_only/3` — body-only 429 with `global: false`.
  - `user_429_retry_after_header/3` — only the standard `Retry-After` header, no body, no `x-ratelimit-*`.

- **`ratelimiter_test.exs`** — three new tests assert that the gen_statem transitions into `:global_limit` in each of these header-stripped scenarios. A `spin_until_state/3` helper polls `:sys.get_state/1` to observe the transition (with timeout).

```
$ mix test test/nostrum/api/ratelimiter_test.exs
..................
Finished in 14.4 seconds (14.4s async, 0.00s sync)
18 tests, 0 failures
```

Full test suite: 215 tests, 1 failure — pre-existing typing violation in `consumer_group_test.exs` (verified identical failure on `origin/master`).

`mix credo` and `mix format --check-formatted` are clean for the touched files.

